### PR TITLE
DatePicker tweaks for using it in `dateRange` mode

### DIFF
--- a/src/Modules/DatePicker.react.js
+++ b/src/Modules/DatePicker.react.js
@@ -151,7 +151,7 @@ class DatePicker extends Component {
                                             })}
                                             onClick={this._onPresetClick.bind(this, 'monthToDate')}
                                         >
-                                            Month-To-Date
+                                            Past 30 Days
                                         </a>
                                     </li>
 
@@ -329,7 +329,25 @@ class DatePicker extends Component {
                 (dateStart && dateEnd && isDateBeforeDateStart) ||
                 (dateType === 'dateStart' && dateStart && dateEnd && date.isBefore(this._convertTimestamp(dateEnd)))
             ) {
-                dateObj.dateStart = date.unix();
+                let unixTimestamp;
+
+                // If the start date is in UTC, it is necessary to adjust it to user's timezone
+                // i.e. it will be the start of some day (12:00 AM) UTC; we need the same time but local
+                if (date._isUTC) {
+                    const tweakedStartDate = moment(date).subtract(moment().utcOffset(), 'minutes');
+                    unixTimestamp = tweakedStartDate.unix();
+                } else {
+                    unixTimestamp = date.unix();
+                }
+
+                dateObj.dateStart = unixTimestamp;
+
+                // In dateRange mode, selection of a single date should set this as start _and_ end
+                // The caller should interpret this as beginning of that day to end of that day, in appropriate timezone
+                if (!dateEnd) {
+                    dateObj.dateEnd = unixTimestamp;
+                }
+
                 this.props.onChange(dateObj);
 
                 this.setState({ presetLink: 'custom' });
@@ -341,7 +359,15 @@ class DatePicker extends Component {
                 (dateStart && dateEnd && isDateBeforeDateEnd) ||
                 (dateStart && dateEnd && isDateAfterDateEnd)
             )) {
-                dateObj.dateEnd = date.unix();
+                // If the end date is in UTC, it is necessary to adjust it to user's timezone
+                // i.e. it will be the start of some day (12:00 AM) UTC; we need the same time local
+                if (date._isUTC) {
+                    const tweakedEndDate = moment(date).subtract(moment().utcOffset(), 'minutes');
+                    dateObj.dateEnd = tweakedEndDate.unix();
+                } else {
+                    dateObj.endDate = date.unx();
+                }
+
                 this.props.onChange(dateObj);
 
                 this.setState({ presetLink: 'custom' });


### PR DESCRIPTION
* Update copy for "Month-To-Date" to be "Past 30 Days" as that more accurately describes the functionality of that preset.
* Selecting a single date when the calendar is in date range mode sets this to both the start and end date.
* Handle some UTC vs. Local quirks with selecting start and end dates of a custom range.  It was consistently sending back start of day (12:00 AM midnight) for the selected days, but sometimes it was Local and other times it was UTC.  Kind of a nightmare for the consuming component to figure out what the user actually intended!  This makes it consistently local.