### PR TITLE
Make Comment component "editable"

### DIFF
--- a/docs/src/js/components/ElementsComment.react.js
+++ b/docs/src/js/components/ElementsComment.react.js
@@ -31,8 +31,8 @@ export default class CommentSample extends React.Component {
         super(props);
 
         this.state = {
-            editableCommentText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
-            editableComment2Text: 'Pellentesque sagittis quam enim, a euismod nisl tristique ac. Duis rutrum accumsan nisl sit amet congue. Vivamus ut convallis velit, nec adipiscing mi. Sed semper dui ut velit eleifend tincidunt.',
+            editableCommentText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+            editableComment2Text: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
             isRemoveBannerOpen: false,
             isSaveBannerOpen: false
         };
@@ -58,14 +58,25 @@ export default class CommentSample extends React.Component {
 
                 <Comment
                     canDelete
-                    canEdit
+                    canEdit={false}
                     detailsPosition="right"
                     isEditable
                     name="Jessica Jones"
                     onDelete={this._onRemoveComment}
+                    time={1536941520}
+                >
+                    {'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'}
+                </Comment>
+
+                <Comment
+                    canDelete
+                    canEdit
+                    isEditable
+                    name="Joe Smith"
+                    onDelete={this._onRemoveComment}
                     onSaveEdit={this._onSaveComment2}
                     text={editableComment2Text}
-                    time={1536941520}
+                    time={1536941640}
                 >
                     {editableComment2Text}
                 </Comment>
@@ -231,11 +242,31 @@ export default class ElmentsComment extends React.Component {
                     </Header.Subheader>
                 </Header>
 
-                <p>When the comment details are right-aligned, the edit and delete actions are left-aligned.</p>
+                <p>
+                    Use the <code>isEditable</code> prop to set whether or not a comment is editable or deletable
+                    <em>at all</em> (versus simply being read-only).  <code>isEditable</code> defaults to false, so set
+                    it to true for editable comments.
+                </p>
+
+                <p>
+                    Likely there will be some business rules around <em>who</em> may edit and delete comments.  For
+                    example, let's say the rules are that a comment may only be edited by its original author, but that
+                    certain "moderator" users are authorized to delete comments (e.g. comments deemed "inappropriate").
+                    You should use the <code>canDelete</code> and <code>canEdit</code> props to drive these kinds of
+                    permissions and selectively make deletion and editing available. The example below demonstrates
+                    this: Joe Smith's comments are editable and deleteable; Jessica Jone's comment is only deletable
+                    (i.e. let's say that Joe Smith is the logged in user and has moderation privileges.)
+                </p>
+
+                <p>
+                    When the comment details are right-aligned, the edit and delete action menu is left-aligned, and
+                    vice versa.
+                </p>
 
                 <Comment
                     canDelete
                     canEdit
+                    detailsPosition="right"
                     isEditable
                     name="Joe Smith"
                     onDelete={this._onRemoveComment}
@@ -248,14 +279,25 @@ export default class ElmentsComment extends React.Component {
 
                 <Comment
                     canDelete
-                    canEdit
-                    detailsPosition="right"
+                    canEdit={false}
                     isEditable
                     name="Jessica Jones"
                     onDelete={this._onRemoveComment}
+                    time={1536941520}
+                >
+                    {'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'}
+                </Comment>
+
+                <Comment
+                    canDelete
+                    canEdit
+                    detailsPosition="right"
+                    isEditable
+                    name="Joe Smith"
+                    onDelete={this._onRemoveComment}
                     onSaveEdit={this._onSaveComment2}
                     text={editableComment2Text}
-                    time={1536941520}
+                    time={1536941640}
                 >
                     {editableComment2Text}
                 </Comment>

--- a/docs/src/js/components/ElementsComment.react.js
+++ b/docs/src/js/components/ElementsComment.react.js
@@ -2,7 +2,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Card, Comment, Header, Image, TitleBar } from 'react-cm-ui';
+import { Banner, Card, Comment, Header, Image, TitleBar } from 'react-cm-ui';
 
 // Docs UI Components
 import Block from 'components/UI/Block.react';
@@ -23,14 +23,101 @@ export default class CommentSample extends React.Component {
     }
 }`;
 
-export default class ElmentsComment extends React.Component {
+const editableCommentSample = `import React from 'react';
+import { Banner, Comment } from 'react-cm-ui';
+
+export default class CommentSample extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            editableCommentText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
+            isRemoveBannerOpen: false,
+            isSaveBannerOpen: false
+        };
+    }
+
     render() {
+        const { editableCommentText, isRemoveBannerOpen, isSaveBannerOpen } = this.state;
+
+        return (
+            <Comment
+                canEdit
+                canRemove
+                isEditable
+                name="Joe Smith"
+                onRemove={this._onRemoveComment}
+                onSaveEdit={this._onSaveComment}
+                text={editableCommentText}
+                time={1531648822}
+            >
+                {editableCommentText}
+            </Comment>
+        );
+    }
+
+    _onCloseRemoveBanner() {
+        this.setState({ isRemoveBannerOpen: false });
+    }
+
+    _onCloseSaveBanner() {
+        this.setState({ isSaveBannerOpen: false });
+    }
+
+    _onRemoveComment() {
+        // TODO - Issue API call or whatever to delete the persisted comment data
+
+        this.setState({ isRemoveBannerOpen: true }, () => {
+            setTimeout(() => this.setState({ isRemoveBannerOpen: false}), 2000);
+        });
+    }
+
+    _onSaveComment(updatedComment) {
+        // TODO - Issue API call or whatever to delete the persisted comment data
+
+        this.setState({ editableCommentText: updatedComment, isSaveBannerOpen: true }, () => {
+            setTimeout(() => this.setState({ isSaveBannerOpen: false}), 2000);
+        });
+    }
+}`;
+
+export default class ElmentsComment extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            editableCommentText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
+            isRemoveBannerOpen: false,
+            isSaveBannerOpen: false
+        };
+
+        this._onCloseRemoveBanner = this._onCloseRemoveBanner.bind(this);
+        this._onCloseSaveBanner = this._onCloseSaveBanner.bind(this);
+        this._onRemoveComment = this._onRemoveComment.bind(this);
+        this._onSaveComment = this._onSaveComment.bind(this);
+    }
+
+    render() {
+        const { editableCommentText, isRemoveBannerOpen, isSaveBannerOpen } = this.state;
+
         const props = [
             {
                 name: 'avatarSrc',
                 type: 'string',
                 default: '',
                 description: 'Show the user\'s avatar.',
+                allowedTypes: ''
+            }, {
+                name: 'canEdit',
+                type: 'bool',
+                default: 'false',
+                description: 'Whether or not the user is permitted to edit and save an update to the comment (assuming that isEditable is true and it is editable in the first place).',
+                allowedTypes: ''
+            }, {
+                name: 'canRemove',
+                type: 'bool',
+                default: 'false',
+                description: 'Whether or not the user is permitted to remove (delete) the comment (assuming that isEditable is true and it is editable in the first place).',
                 allowedTypes: ''
             }, {
                 name: 'children',
@@ -47,9 +134,15 @@ export default class ElmentsComment extends React.Component {
             }, {
                 name: 'detailsPosition',
                 type: 'enum',
-                default: '',
+                default: 'left',
                 description: 'Position the comment\'s details on either the left or right.',
                 allowedTypes: 'left, right'
+            }, {
+                name: 'isEditable',
+                type: 'bool',
+                default: 'false',
+                description: 'Whether or not the comment is editable.  At all.  If it is editable, but certain users may not have permission, use canEdit and canRemove to govern that.',
+                allowedTypes: ''
             }, {
                 name: 'name *',
                 type: 'string',
@@ -61,6 +154,12 @@ export default class ElmentsComment extends React.Component {
                 type: 'object',
                 default: '',
                 description: 'Supply any inline styles to the List\'s container. Mainly used for padding and margins.',
+                allowedTypes: ''
+            }, {
+                name: 'text',
+                type: 'string',
+                default: '',
+                description: 'In addition to passing it in as the child, you must pass the text/contents of a comment in here if you want to make it editable.',
                 allowedTypes: ''
             }, {
                 name: 'time *',
@@ -96,7 +195,72 @@ export default class ElmentsComment extends React.Component {
                 <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
                     {commentSample}
                 </Highlighter>
+
+                {/* Editable Comment */}
+                <Header anchor="divider" size="large" style={{ marginTop: '55px' }} sub={true}>
+                    Editable Comments
+                    <Header.Subheader>
+                        A comment can be editable and deletable.
+                    </Header.Subheader>
+                </Header>
+
+                <Comment
+                    canEdit
+                    canRemove
+                    isEditable
+                    name="Joe Smith"
+                    onRemove={this._onRemoveComment}
+                    onSaveEdit={this._onSaveComment}
+                    text={editableCommentText}
+                    time={1536941364}
+                >
+                    {editableCommentText}
+                </Comment>
+
+                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                    {editableCommentSample}
+                </Highlighter>
+
+                <Banner
+                    id="remove-success"
+                    level="success"
+                    isOpen={isRemoveBannerOpen}
+                    message="Comment Removed!"
+                    onClose={this._onCloseRemoveBanner}
+                    title="Comment Removed"
+                    type="notification"
+                />
+
+                <Banner
+                    id="save-success"
+                    level="success"
+                    isOpen={isSaveBannerOpen}
+                    message="Comment Saved!"
+                    onClose={this._onCloseSaveBanner}
+                    title="Comment Saved"
+                    type="notification"
+                />
             </Main>
         );
+    }
+
+    _onCloseRemoveBanner() {
+        this.setState({ isRemoveBannerOpen: false });
+    }
+
+    _onCloseSaveBanner() {
+        this.setState({ isSaveBannerOpen: false });
+    }
+
+    _onRemoveComment() {
+        this.setState({ isRemoveBannerOpen: true }, () => {
+            setTimeout(() => this.setState({ isRemoveBannerOpen: false}), 2000);
+        });
+    }
+
+    _onSaveComment(updatedComment) {
+        this.setState({ editableCommentText: updatedComment, isSaveBannerOpen: true }, () => {
+            setTimeout(() => this.setState({ isSaveBannerOpen: false}), 2000);
+        });
     }
 }

--- a/docs/src/js/components/ElementsComment.react.js
+++ b/docs/src/js/components/ElementsComment.react.js
@@ -73,7 +73,7 @@ export default class CommentSample extends React.Component {
     }
 
     _onSaveComment(updatedComment) {
-        // TODO - Issue API call or whatever to delete the persisted comment data
+        // TODO - Issue API call or whatever to update the persisted comment data
 
         this.setState({ editableCommentText: updatedComment, isSaveBannerOpen: true }, () => {
             setTimeout(() => this.setState({ isSaveBannerOpen: false}), 2000);

--- a/docs/src/js/components/ElementsComment.react.js
+++ b/docs/src/js/components/ElementsComment.react.js
@@ -42,11 +42,11 @@ export default class CommentSample extends React.Component {
 
         return (
             <Comment
+                canDelete
                 canEdit
-                canRemove
                 isEditable
                 name="Joe Smith"
-                onRemove={this._onRemoveComment}
+                onDelete={this._onRemoveComment}
                 onSaveEdit={this._onSaveComment}
                 text={editableCommentText}
                 time={1531648822}
@@ -87,6 +87,7 @@ export default class ElmentsComment extends React.Component {
 
         this.state = {
             editableCommentText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
+            editableComment2Text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
             isRemoveBannerOpen: false,
             isSaveBannerOpen: false
         };
@@ -95,10 +96,11 @@ export default class ElmentsComment extends React.Component {
         this._onCloseSaveBanner = this._onCloseSaveBanner.bind(this);
         this._onRemoveComment = this._onRemoveComment.bind(this);
         this._onSaveComment = this._onSaveComment.bind(this);
+        this._onSaveComment2 = this._onSaveComment2.bind(this);
     }
 
     render() {
-        const { editableCommentText, isRemoveBannerOpen, isSaveBannerOpen } = this.state;
+        const { editableCommentText, editableComment2Text, isRemoveBannerOpen, isSaveBannerOpen } = this.state;
 
         const props = [
             {
@@ -108,16 +110,16 @@ export default class ElmentsComment extends React.Component {
                 description: 'Show the user\'s avatar.',
                 allowedTypes: ''
             }, {
+                name: 'canDelete',
+                type: 'bool',
+                default: 'false',
+                description: 'Whether or not the user is permitted to remove (delete) the comment (assuming that isEditable is true and it is editable in the first place).',
+                allowedTypes: ''
+            }, {
                 name: 'canEdit',
                 type: 'bool',
                 default: 'false',
                 description: 'Whether or not the user is permitted to edit and save an update to the comment (assuming that isEditable is true and it is editable in the first place).',
-                allowedTypes: ''
-            }, {
-                name: 'canRemove',
-                type: 'bool',
-                default: 'false',
-                description: 'Whether or not the user is permitted to remove (delete) the comment (assuming that isEditable is true and it is editable in the first place).',
                 allowedTypes: ''
             }, {
                 name: 'children',
@@ -181,7 +183,7 @@ export default class ElmentsComment extends React.Component {
                 </Card>
 
                 {/* Comment */}
-                <Header anchor="divider" size="large" style={{ marginTop: '55px' }} sub={true}>
+                <Header anchor="comment" size="large" style={{ marginTop: '55px' }} sub={true}>
                     Comment
                     <Header.Subheader>
                         A user's comment.
@@ -197,7 +199,7 @@ export default class ElmentsComment extends React.Component {
                 </Highlighter>
 
                 {/* Editable Comment */}
-                <Header anchor="divider" size="large" style={{ marginTop: '55px' }} sub={true}>
+                <Header anchor="editable-comment" size="large" style={{ marginTop: '55px' }} sub={true}>
                     Editable Comments
                     <Header.Subheader>
                         A comment can be editable and deletable.
@@ -205,11 +207,11 @@ export default class ElmentsComment extends React.Component {
                 </Header>
 
                 <Comment
+                    canDelete
                     canEdit
-                    canRemove
                     isEditable
                     name="Joe Smith"
-                    onRemove={this._onRemoveComment}
+                    onDelete={this._onRemoveComment}
                     onSaveEdit={this._onSaveComment}
                     text={editableCommentText}
                     time={1536941364}
@@ -220,6 +222,28 @@ export default class ElmentsComment extends React.Component {
                 <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
                     {editableCommentSample}
                 </Highlighter>
+
+                {/* Editable Comment with Details on Right and Actions on Left */}
+                <Header anchor="editable-comment-right" size="large" style={{ marginTop: '55px' }} sub>
+                    Editable comment with opposite alignment.
+                    <Header.Subheader>
+                        When the comment details are right-aligned, the edit and delete actions are left-aligned.
+                    </Header.Subheader>
+                </Header>
+
+                <Comment
+                    canDelete
+                    canEdit
+                    detailsPosition="right"
+                    isEditable
+                    name="Joe Smith"
+                    onDelete={this._onRemoveComment}
+                    onSaveEdit={this._onSaveComment2}
+                    text={editableComment2Text}
+                    time={1536941364}
+                >
+                    {editableComment2Text}
+                </Comment>
 
                 <Banner
                     id="remove-success"
@@ -260,6 +284,12 @@ export default class ElmentsComment extends React.Component {
 
     _onSaveComment(updatedComment) {
         this.setState({ editableCommentText: updatedComment, isSaveBannerOpen: true }, () => {
+            setTimeout(() => this.setState({ isSaveBannerOpen: false}), 2000);
+        });
+    }
+
+    _onSaveComment2(updatedComment) {
+        this.setState({ editableComment2Text: updatedComment, isSaveBannerOpen: true }, () => {
             setTimeout(() => this.setState({ isSaveBannerOpen: false}), 2000);
         });
     }

--- a/docs/src/js/components/ElementsComment.react.js
+++ b/docs/src/js/components/ElementsComment.react.js
@@ -46,6 +46,7 @@ export default class CommentSample extends React.Component {
                 <Comment
                     canDelete
                     canEdit
+                    detailsPosition="right"
                     isEditable
                     name="Joe Smith"
                     onDelete={this._onRemoveComment}
@@ -59,7 +60,6 @@ export default class CommentSample extends React.Component {
                 <Comment
                     canDelete
                     canEdit={false}
-                    detailsPosition="right"
                     isEditable
                     name="Jessica Jones"
                     onDelete={this._onRemoveComment}
@@ -71,6 +71,7 @@ export default class CommentSample extends React.Component {
                 <Comment
                     canDelete
                     canEdit
+                    detailsPosition="right"
                     isEditable
                     name="Joe Smith"
                     onDelete={this._onRemoveComment}

--- a/docs/src/js/components/ElementsComment.react.js
+++ b/docs/src/js/components/ElementsComment.react.js
@@ -32,27 +32,44 @@ export default class CommentSample extends React.Component {
 
         this.state = {
             editableCommentText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
+            editableComment2Text: 'Pellentesque sagittis quam enim, a euismod nisl tristique ac. Duis rutrum accumsan nisl sit amet congue. Vivamus ut convallis velit, nec adipiscing mi. Sed semper dui ut velit eleifend tincidunt.',
             isRemoveBannerOpen: false,
             isSaveBannerOpen: false
         };
     }
 
     render() {
-        const { editableCommentText, isRemoveBannerOpen, isSaveBannerOpen } = this.state;
+        const { editableCommentText, editableComment2Text, isRemoveBannerOpen, isSaveBannerOpen } = this.state;
 
         return (
-            <Comment
-                canDelete
-                canEdit
-                isEditable
-                name="Joe Smith"
-                onDelete={this._onRemoveComment}
-                onSaveEdit={this._onSaveComment}
-                text={editableCommentText}
-                time={1531648822}
-            >
-                {editableCommentText}
-            </Comment>
+            <div>
+                <Comment
+                    canDelete
+                    canEdit
+                    isEditable
+                    name="Joe Smith"
+                    onDelete={this._onRemoveComment}
+                    onSaveEdit={this._onSaveComment}
+                    text={editableCommentText}
+                    time={1531648822}
+                >
+                    {editableCommentText}
+                </Comment>
+
+                <Comment
+                    canDelete
+                    canEdit
+                    detailsPosition="right"
+                    isEditable
+                    name="Jessica Jones"
+                    onDelete={this._onRemoveComment}
+                    onSaveEdit={this._onSaveComment2}
+                    text={editableComment2Text}
+                    time={1536941520}
+                >
+                    {editableComment2Text}
+                </Comment>
+            </div>
         );
     }
 
@@ -79,6 +96,14 @@ export default class CommentSample extends React.Component {
             setTimeout(() => this.setState({ isSaveBannerOpen: false}), 2000);
         });
     }
+
+    _onSaveComment2(updatedComment) {
+        // TODO - Issue API call or whatever to update the persisted comment data
+
+        this.setState({ editableComment2Text: updatedComment, isSaveBannerOpen: true }, () => {
+            setTimeout(() => this.setState({ isSaveBannerOpen: false}), 2000);
+        });
+    }
 }`;
 
 export default class ElmentsComment extends React.Component {
@@ -87,7 +112,7 @@ export default class ElmentsComment extends React.Component {
 
         this.state = {
             editableCommentText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
-            editableComment2Text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor.',
+            editableComment2Text: 'Pellentesque sagittis quam enim, a euismod nisl tristique ac. Duis rutrum accumsan nisl sit amet congue. Vivamus ut convallis velit, nec adipiscing mi. Sed semper dui ut velit eleifend tincidunt.',
             isRemoveBannerOpen: false,
             isSaveBannerOpen: false
         };
@@ -206,6 +231,8 @@ export default class ElmentsComment extends React.Component {
                     </Header.Subheader>
                 </Header>
 
+                <p>When the comment details are right-aligned, the edit and delete actions are left-aligned.</p>
+
                 <Comment
                     canDelete
                     canEdit
@@ -219,31 +246,23 @@ export default class ElmentsComment extends React.Component {
                     {editableCommentText}
                 </Comment>
 
-                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                    {editableCommentSample}
-                </Highlighter>
-
-                {/* Editable Comment with Details on Right and Actions on Left */}
-                <Header anchor="editable-comment-right" size="large" style={{ marginTop: '55px' }} sub>
-                    Editable comment with opposite alignment.
-                    <Header.Subheader>
-                        When the comment details are right-aligned, the edit and delete actions are left-aligned.
-                    </Header.Subheader>
-                </Header>
-
                 <Comment
                     canDelete
                     canEdit
                     detailsPosition="right"
                     isEditable
-                    name="Joe Smith"
+                    name="Jessica Jones"
                     onDelete={this._onRemoveComment}
                     onSaveEdit={this._onSaveComment2}
                     text={editableComment2Text}
-                    time={1536941364}
+                    time={1536941520}
                 >
                     {editableComment2Text}
                 </Comment>
+
+                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                    {editableCommentSample}
+                </Highlighter>
 
                 <Banner
                     id="remove-success"

--- a/docs/src/js/components/ElementsComment.react.js
+++ b/docs/src/js/components/ElementsComment.react.js
@@ -144,13 +144,13 @@ export default class ElmentsComment extends React.Component {
                 name: 'avatarSrc',
                 type: 'string',
                 default: '',
-                description: 'Show the user\'s avatar.',
+                description: 'Show the comment author\'s avatar.',
                 allowedTypes: ''
             }, {
                 name: 'canDelete',
                 type: 'bool',
                 default: 'false',
-                description: 'Whether or not the user is permitted to remove (delete) the comment (assuming that isEditable is true and it is editable in the first place).',
+                description: 'Whether or not the user is permitted to delete the comment (assuming that isEditable is true and it is editable in the first place).',
                 allowedTypes: ''
             }, {
                 name: 'canEdit',
@@ -180,7 +180,7 @@ export default class ElmentsComment extends React.Component {
                 name: 'isEditable',
                 type: 'bool',
                 default: 'false',
-                description: 'Whether or not the comment is editable.  At all.  If it is editable, but certain users may not have permission, use canEdit and canRemove to govern that.',
+                description: 'Whether or not the comment is editable.  At all.  If it is editable, but certain users may not have Edit and/or Delete permission, use canEdit and canDelete to govern that.',
                 allowedTypes: ''
             }, {
                 name: 'name *',
@@ -192,7 +192,7 @@ export default class ElmentsComment extends React.Component {
                 name: 'style',
                 type: 'object',
                 default: '',
-                description: 'Supply any inline styles to the List\'s container. Mainly used for padding and margins.',
+                description: 'Supply any inline styles to the Comment\'s container. Mainly used for padding and margins.',
                 allowedTypes: ''
             }, {
                 name: 'text',

--- a/docs/src/js/components/ModulesDropdown.react.js
+++ b/docs/src/js/components/ModulesDropdown.react.js
@@ -772,7 +772,7 @@ export default class ModulesDropdown extends React.Component {
                 type: 'enum',
                 default: '',
                 description: 'Color of the button Dropdown.',
-                allowedTypes: 'alert, alternate, disable, light, outline, primary, success, warning'
+                allowedTypes: 'alert, alternate, disable, light, outline, primary, success, transparent, warning'
             }, {
                 name: 'buttonCompact',
                 type: 'bool',

--- a/docs/src/js/components/ModulesDropdown.react.js
+++ b/docs/src/js/components/ModulesDropdown.react.js
@@ -18,7 +18,7 @@ export default class DropdownSample extends React.Component {
 
     render() {
         return (
-            <Dropdown placeholder="select">
+            <Dropdown collapseMenuOnChange placeholder="select">
                 <Dropdown.Item label="Option 1" />
                 <Dropdown.Item label="Option 2" />
                 <Dropdown.Item label="Option 3" />
@@ -68,7 +68,6 @@ export default class ButtonControlledSample extends React.Component {
         return (
             <Dropdown
                 button
-                collapseMenuOnChange
                 placeholder="Button Dropdown"
                 onChange={this._onButtonDropDownChange}
                 value={this.state.buttonDropdownValue}
@@ -141,47 +140,62 @@ export default class ButtonColorSample extends React.Component {
     render() {
         return (
             <div>
-                <Dropdown button buttonColor="alert" text="Alert">
+                <Dropdown button buttonColor="alert" collapseMenuOnChange text="Alert">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="alternate" text="Alternate">
+                <Dropdown button buttonColor="alternate" collapseMenuOnChange text="Alternate">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="disable" text="Disable">
+                <Dropdown button buttonColor="disable" collapseMenuOnChange text="Disable">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="light" text="Light">
+                <Dropdown button buttonColor="light" collapseMenuOnChange text="Light">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="outline" text="Outline">
+                <Dropdown button buttonColor="outline" collapseMenuOnChange text="Outline">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="primary" text="Primary">
+                <Dropdown button buttonColor="primary" collapseMenuOnChange text="Primary">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="secondary" text="Secondary">
+                <Dropdown button buttonColor="secondary" collapseMenuOnChange text="Secondary">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="success" text="Success">
+                <Dropdown button buttonColor="success" collapseMenuOnChange text="Success">
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
 
-                <Dropdown button buttonColor="warning" text="Warning">
+                <Dropdown button buttonColor="warning" collapseMenuOnChange text="Warning">
+                    <Dropdown.Item label="Option 1" />
+                    <Dropdown.Item label="Option 2" />
+                </Dropdown>
+
+                <Dropdown
+                    button
+                    buttonColor="transparent"
+                    buttonCompact
+                    collapseMenuOnChange
+                    iconColor="static"
+                    iconTitle={'Transparent icon button dropdown'}
+                    iconType="ellipsis-h"
+                    onChange={() => { }}
+                    style={{ margin: 0 }}
+                >
                     <Dropdown.Item label="Option 1" />
                     <Dropdown.Item label="Option 2" />
                 </Dropdown>
@@ -198,7 +212,7 @@ export default class ButtonCompactSample extends React.Component {
 
     render() {
         return (
-            <Dropdown button={true} buttonCompact={true} placeholder="Button Compact Dropdown">
+            <Dropdown button buttonCompact collapseMenuOnChange placeholder="Button Compact Dropdown">
                 <Dropdown.Item label="Option 1" />
                 <Dropdown.Item label="Option 2" />
                 <Dropdown.Item label="Option 3" />
@@ -311,9 +325,10 @@ export default class IconSample extends React.Component {
         return (
             <div>
                 <Dropdown
-                    button={true}
-                    buttonCompact={true}
-                    iconInverse={true}
+                    button
+                    buttonCompact
+                    collapseMenuOnChange
+                    iconInverse
                     iconSize="xlarge"
                     iconType="ellipsis-h"
                 >
@@ -326,10 +341,10 @@ export default class IconSample extends React.Component {
                 <Dropdown
                     iconType="plus"
                     onChange={this._onSelectionCustomOptionsChange.bind(this)}
-                    selectionOptionComponent={SelectionCustomComponent}
                     options={selectionCustomOptions}
-                    placeholder="Select a status"
-                    selection={true}
+                    placeholder="Select a user"
+                    selectionOptionComponent={SelectionCustomComponent}
+                    selection
                     value={this.state.selectionCustomOptionsValue}
                 />
             </div<
@@ -783,7 +798,7 @@ export default class ModulesDropdown extends React.Component {
                 name: 'collapseMenuOnChange',
                 type: 'bool',
                 default: '',
-                description: 'Whether or not to automatically collapse the menu when an option is selected (regardless of whether or not the value changes).',
+                description: 'Whether or not to automatically collapse the menu when an option is selected (regardless of whether or not the value changes).  it is a good idea to set this prop to true if you\'re handing onChange but not updating the value (e.g. if you\'re using a button dropdown as an aciton menu).',
                 allowedTypes: ''
             },{
                 name: 'className',
@@ -820,6 +835,12 @@ export default class ModulesDropdown extends React.Component {
                 type: 'enum',
                 default: '',
                 description: 'Change the size of the icon inside of the Dropdown.',
+                allowedTypes: ''
+            }, {
+                name: 'iconTitle',
+                type: 'string',
+                default: '',
+                description: 'Set the title (tooltip) of the icon inside of the Dropdown menu.  If not specified, placeholder or text value is used instead.',
                 allowedTypes: ''
             }, {
                 name: 'iconType',
@@ -910,6 +931,12 @@ export default class ModulesDropdown extends React.Component {
                 type: 'object',
                 default: '',
                 description: 'Supply any inline styles to the Dropdown\'s container. Mainly used for padding and margins.',
+                allowedTypes: ''
+            }, {
+                name: 'text',
+                type: 'string, object',
+                default: '',
+                description: 'Set text of Dropdown; an alternative to placeholder.',
                 allowedTypes: ''
             }, {
                 name: 'theme',
@@ -1077,11 +1104,11 @@ export default class ModulesDropdown extends React.Component {
                     <Header anchor="dropdown" size="large" style={{ marginTop: '55px' }} sub={true}>
                         Dropdown
                         <Header.Subheader>
-                            A baisc Dropdown.
+                            A basic Dropdown.
                         </Header.Subheader>
                     </Header>
 
-                    <Dropdown placeholder="select">
+                    <Dropdown collapseMenuOnChange placeholder="select">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                         <Dropdown.Item label="Option 3" />
@@ -1089,7 +1116,7 @@ export default class ModulesDropdown extends React.Component {
                     </Dropdown>
 
                     <div style={{ textAlign: 'right' }}>
-                        <Dropdown placeholder="select">
+                        <Dropdown collapseMenuOnChange placeholder="select">
                             <Dropdown.Item label="Option 1" />
                             <Dropdown.Item label="Really Long Option 2" />
                             <Dropdown.Item label="Option 3" />
@@ -1124,7 +1151,9 @@ export default class ModulesDropdown extends React.Component {
                     <Header anchor="button-controlled" size="large" style={{ marginTop: '55px' }} sub>
                         Button Dropdown as a Controlled Component
                         <Header.Subheader>
-                            A Button Dropdown can also act as a controlled component.
+                            A Button Dropdown can act as a typical React controlled component.  This means that we set the
+                            <code>value</code> prop, handle the <code>onChange</code> event and update whatever state we
+                            we're using for <code>value</code>.
                         </Header.Subheader>
                     </Header>
 
@@ -1190,42 +1219,42 @@ export default class ModulesDropdown extends React.Component {
                     <Grid>
                         <Grid.Row stackable>
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="alert" text="Alert" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="alert" collapseMenuOnChange text="Alert" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
                             </Grid.Column>
 
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="alternate" text="Alternate" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="alternate" collapseMenuOnChange text="Alternate" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
                             </Grid.Column>
 
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="disable" text="Disable" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="disable" collapseMenuOnChange text="Disable" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
                             </Grid.Column>
 
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="light" text="Light" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="light" collapseMenuOnChange text="Light" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
                             </Grid.Column>
 
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="outline" text="Outline" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="outline" collapseMenuOnChange text="Outline" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
                             </Grid.Column>
 
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="primary" text="Primary" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="primary" collapseMenuOnChange text="Primary" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
@@ -1233,24 +1262,46 @@ export default class ModulesDropdown extends React.Component {
                         </Grid.Row>
                         <Grid.Row stackable>
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="secondary" text="Secondary" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="secondary" collapseMenuOnChange text="Secondary" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
                             </Grid.Column>
 
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="success" text="Success" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="success" collapseMenuOnChange text="Success" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
                             </Grid.Column>
 
                             <Grid.Column width={6} tablet={4} laptop={2}>
-                                <Dropdown button buttonColor="warning" text="Warning" style={{ maxWidth: '200px', width: '100%' }}>
+                                <Dropdown button buttonColor="warning" collapseMenuOnChange text="Warning" style={{ maxWidth: '200px', width: '100%' }}>
                                     <Dropdown.Item label="Option 1" />
                                     <Dropdown.Item label="Option 2" />
                                 </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <div style={{ flex: '0 0 auto' }}>
+                                    <Dropdown
+                                        button
+                                        buttonColor="transparent"
+                                        buttonCompact
+                                        collapseMenuOnChange
+                                        iconColor="static"
+                                        iconTitle={'Transparent icon button dropdown'}
+                                        iconType="ellipsis-h"
+                                        onChange={() => { }}
+                                        style={{ margin: 0 }}
+                                    >
+                                        <Dropdown.Item label="Option 1" />
+                                        <Dropdown.Item label="Option 2" />
+                                    </Dropdown>
+                                    <div style={{ display: 'inline-flex' }}>
+                                        {'(Transparent)'}
+                                    </div>
+                                </div>
                             </Grid.Column>
                         </Grid.Row>
                     </Grid>
@@ -1267,7 +1318,7 @@ export default class ModulesDropdown extends React.Component {
                         </Header.Subheader>
                     </Header>
 
-                    <Dropdown button={true} buttonCompact={true} placeholder="Button Compact Dropdown">
+                    <Dropdown button buttonCompact collapseMenuOnChange placeholder="Button Compact Dropdown">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                         <Dropdown.Item label="Option 3" />
@@ -1326,14 +1377,14 @@ export default class ModulesDropdown extends React.Component {
                         </Header.Subheader>
                     </Header>
 
-                    <Dropdown iconType="plus" placeholder="select">
+                    <Dropdown collapseMenuOnChange iconType="plus" placeholder="select">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                         <Dropdown.Item label="Option 3" />
                         <Dropdown.Item label="Option 4" />
                     </Dropdown><br /><br />
 
-                    <Dropdown button iconSize="small" iconPosition="left" iconType="plus" placeholder="Button Placeholder/Icon">
+                    <Dropdown button collapseMenuOnChange iconSize="small" iconPosition="left" iconType="plus" placeholder="Button Placeholder/Icon">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                         <Dropdown.Item label="Option 3" />
@@ -1341,9 +1392,10 @@ export default class ModulesDropdown extends React.Component {
                     </Dropdown><br /><br />
 
                     <Dropdown
-                        button={true}
-                        buttonCompact={true}
-                        iconInverse={true}
+                        button
+                        buttonCompact
+                        collapseMenuOnChange
+                        iconInverse
                         iconSize="xlarge"
                         iconType="ellipsis-h"
                     >
@@ -1356,10 +1408,10 @@ export default class ModulesDropdown extends React.Component {
                     <Dropdown
                         iconType="plus"
                         onChange={this._onSelectionCustomOptionsChange.bind(this)}
-                        selectionOptionComponent={SelectionCustomComponent}
                         options={selectionCustomOptions}
-                        placeholder="Select a status"
-                        selection={true}
+                        placeholder="Select a user"
+                        selectionOptionComponent={SelectionCustomComponent}
+                        selection
                         value={this.state.selectionCustomOptionsValue}
                     />
 

--- a/docs/src/js/components/ModulesDropdown.react.js
+++ b/docs/src/js/components/ModulesDropdown.react.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Dropdown, Header, SubNavigation, TitleBar } from 'react-cm-ui';
+import { Card, Dropdown, Grid, Header, SubNavigation, TitleBar } from 'react-cm-ui';
 
 // Docs UI Components
 import Block from 'components/UI/Block.react';
@@ -37,7 +37,7 @@ export default class ButtonSample extends React.Component {
 
     render() {
         return (
-            <Dropdown button={true} placeholder="Button Dropdown">
+            <Dropdown button collapseMenuOnChange placeholder="Button Dropdown">
                 <Dropdown.Item label="Option 1" />
                 <Dropdown.Item label="Option 2" />
                 <Dropdown.Item label="Option 3" />
@@ -46,6 +46,92 @@ export default class ButtonSample extends React.Component {
         );
     }
 
+}`;
+
+const buttonControlledSample = `import React from 'react';
+
+import { Dropdown } from 'react-cm-ui';
+
+export default class ButtonControlledSample extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            buttonDropdownValue: null
+        };
+
+        this._onButtonDropDownChange = this._onButtonDropDownChange.bind(this);
+    }
+
+    render() {
+        return (
+            <Dropdown
+                button
+                collapseMenuOnChange
+                placeholder="Button Dropdown"
+                onChange={this._onButtonDropDownChange}
+                value={this.state.buttonDropdownValue}
+            >
+                <Dropdown.Item label="Option 1" />
+                <Dropdown.Item label="Option 2" />
+                <Dropdown.Item label="Option 3" />
+                <Dropdown.Item label="Option 4" />
+            </Dropdown>
+        );
+    }
+
+    _onButtonDropDownChange(selectedOption) {
+        this.setState({ buttonDropdownValue: selectedOption });
+    }
+}`;
+
+const buttonMenuSample = `import React from 'react';
+
+import { Dropdown } from 'react-cm-ui';
+
+export default class ButtonMenuSample extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            buttonMenuAction: null
+        };
+
+        this._onButtonDropDownMenuChange = this._onButtonDropDownMenuChange.bind(this);
+    }
+
+    render() {
+        return (
+            <div>
+                {this.state.buttonMenuAction ? (
+                    <p>You selected: <strong>{this.state.buttonMenuAction}</strong></p>
+                ) : (
+                    <p>Select something...</p>
+                )}
+
+                <Dropdown
+                    button
+                    collapseMenuOnChange
+                    onChange={this._onButtonDropDownMenuChange}
+                    placeholder="Button Dropdown Menu"
+                >
+                    <Dropdown.Item label="Action 1" />
+                    <Dropdown.Item label="Action 2" />
+                    <Dropdown.Item label="Action 3" />
+                    <Dropdown.Item label="Action 4" />
+                </Dropdown>
+            </div>
+        );
+    }
+
+    _onButtonDropDownMenuChange(selectedOption) {
+        // TODO: Do whatever it is you want to do with the selected option
+        this.setState({ buttonMenuAction: selectedOption.label }, () => {
+            setTimeout(() => { this.setState({ buttonMenuAction: null }); }, 2000);
+        });
+    }
 }`;
 
 const buttonColorSample = `import React from 'react';
@@ -669,6 +755,8 @@ export default class ModulesDropdown extends React.Component {
         };
 
         this._onSampleOnChange = this._onSampleOnChange.bind(this);
+        this._onButtonDropDownChange = this._onButtonDropDownChange.bind(this);
+        this._onButtonDropDownMenuChange = this._onButtonDropDownMenuChange.bind(this);
     }
 
     render() {
@@ -692,6 +780,12 @@ export default class ModulesDropdown extends React.Component {
                 description: 'A button can reduce its padding.',
                 allowedTypes: ''
             }, {
+                name: 'collapseMenuOnChange',
+                type: 'bool',
+                default: '',
+                description: 'Whether or not to automatically collapse the menu when an option is selected (regardless of whether or not the value changes).',
+                allowedTypes: ''
+            },{
                 name: 'className',
                 type: 'string',
                 default: '',
@@ -1015,7 +1109,7 @@ export default class ModulesDropdown extends React.Component {
                         </Header.Subheader>
                     </Header>
 
-                    <Dropdown button={true} placeholder="Button Dropdown">
+                    <Dropdown button collapseMenuOnChange placeholder="Button Dropdown">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                         <Dropdown.Item label="Option 3" />
@@ -1026,6 +1120,65 @@ export default class ModulesDropdown extends React.Component {
                         {buttonSample}
                     </Highlighter>
 
+                    {/* Button Dropdown Controlled Component */}
+                    <Header anchor="button-controlled" size="large" style={{ marginTop: '55px' }} sub>
+                        Button Dropdown as a Controlled Component
+                        <Header.Subheader>
+                            A Button Dropdown can also act as a controlled component.
+                        </Header.Subheader>
+                    </Header>
+
+                    <Dropdown
+                        button
+                        onChange={this._onButtonDropDownChange}
+                        placeholder="Button Dropdown"
+                        value={this.state.buttonDropdownValue}
+                    >
+                        <Dropdown.Item label="Option 1" />
+                        <Dropdown.Item label="Option 2" />
+                        <Dropdown.Item label="Option 3" />
+                        <Dropdown.Item label="Option 4" />
+                    </Dropdown>
+
+                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                        {buttonControlledSample}
+                    </Highlighter>
+
+                    {/* Button Menu - Auto-collapse even if value doesn't change */}
+                    <Header anchor="button-menu" size="large" style={{ marginTop: '55px' }} sub>
+                        Button Dropdown Menu
+                        <Header.Subheader>
+                            This is an example of how to use a Button Dropdown as a "menu".  We're not actually updating
+                            its value when an option is selected because we don't want the text of the button to change,
+                            but we are taking advantage of its <code>onChange</code> event do possibly do things in response
+                            to the selection, and we're also setting <code>collapseMenuOnChange</code> in order to force
+                            it to retract the menu.  (This latter is not necessary if we were to use it normally as a
+                            controlled component and update the value; contrast this example with the example above.)
+                        </Header.Subheader>
+                    </Header>
+
+                    {this.state.buttonMenuAction ? (
+                        <p>You selected: <strong>{this.state.buttonMenuAction}</strong></p>
+                    ) : (
+                        <p>Select something...</p>
+                    )}
+
+                    <Dropdown
+                        button
+                        collapseMenuOnChange
+                        onChange={this._onButtonDropDownMenuChange}
+                        placeholder="Button Dropdown Menu"
+                    >
+                        <Dropdown.Item label="Action 1" />
+                        <Dropdown.Item label="Action 2" />
+                        <Dropdown.Item label="Action 3" />
+                        <Dropdown.Item label="Action 4" />
+                    </Dropdown>
+
+                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                        {buttonMenuSample}
+                    </Highlighter>
+
                     {/* Button Color */}
                     <Header anchor="button-color" size="large" style={{ marginTop: '55px' }} sub={true}>
                         Button Color
@@ -1034,50 +1187,73 @@ export default class ModulesDropdown extends React.Component {
                         </Header.Subheader>
                     </Header>
 
-                    <Dropdown button buttonColor="alert" text="Alert">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                    <Grid>
+                        <Grid.Row stackable>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="alert" text="Alert" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
 
-                    <Dropdown button buttonColor="alternate" text="Alternate">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="alternate" text="Alternate" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
 
-                    <Dropdown button buttonColor="disable" text="Disable">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="disable" text="Disable" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
 
-                    <Dropdown button buttonColor="light" text="Light">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="light" text="Light" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
 
-                    <Dropdown button buttonColor="outline" text="Outline">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="outline" text="Outline" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
 
-                    <Dropdown button buttonColor="primary" text="Primary">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="primary" text="Primary" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+                        </Grid.Row>
+                        <Grid.Row stackable>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="secondary" text="Secondary" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
 
-                    <Dropdown button buttonColor="secondary" text="Secondary">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="success" text="Success" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
 
-                    <Dropdown button buttonColor="success" text="Success">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
-
-                    <Dropdown button buttonColor="warning" text="Warning">
-                        <Dropdown.Item label="Option 1" />
-                        <Dropdown.Item label="Option 2" />
-                    </Dropdown>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="warning" text="Warning" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+                        </Grid.Row>
+                    </Grid>
 
                     <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
                         {buttonColorSample}
@@ -1087,7 +1263,7 @@ export default class ModulesDropdown extends React.Component {
                     <Header anchor="button-compact" size="large" style={{ marginTop: '55px' }} sub={true}>
                         Button Compact
                         <Header.Subheader>
-                            A Dropdown can take on the style of a Button.
+                            A Dropdown Button can be made compact.
                         </Header.Subheader>
                     </Header>
 
@@ -1239,7 +1415,7 @@ export default class ModulesDropdown extends React.Component {
                     <Header anchor="on-change" size="large" style={{ marginTop: '55px' }} sub={true}>
                         onChange
                         <Header.Subheader>
-                            onChagne event handler.
+                            onChange event handler.
                         </Header.Subheader>
                     </Header>
 
@@ -1297,11 +1473,11 @@ export default class ModulesDropdown extends React.Component {
                         {selectionMobileSample}
                     </Highlighter>
 
-                    {/* Selection Mutiple */}
+                    {/* Selection Multiple */}
                     <Header anchor="selection-mutiple" size="large" style={{ marginTop: '55px' }} sub={true}>
-                        Selection Mutiple
+                        Selection Multiple
                         <Header.Subheader>
-                            A Dropdown can be a select dropdown where you can choose items.
+                            A Dropdown can be a select dropdown where you can choose multiple items.
                         </Header.Subheader>
                     </Header>
 
@@ -1408,6 +1584,17 @@ export default class ModulesDropdown extends React.Component {
                 {examplesJSX}
             </Main>
         );
+    }
+
+    _onButtonDropDownChange(selectedOption) {
+        this.setState({ buttonDropdownValue: selectedOption });
+    }
+
+    _onButtonDropDownMenuChange(selectedOption) {
+        // TODO: Do whatever it is you want to do with the selected option
+        this.setState({ buttonMenuAction: selectedOption.label }, () => {
+            setTimeout(() => { this.setState({ buttonMenuAction: null}); }, 2000);
+        });
     }
 
     _onDropdownChange(selectedOption) {

--- a/docs/src/js/components/ModulesPrompt.react.js
+++ b/docs/src/js/components/ModulesPrompt.react.js
@@ -19,18 +19,18 @@ export default class InlineSample extends React.Component {
     render() {
         return (
             <div>
-                <Prompt inline={true}>
+                <Prompt inline>
                     <Button color="success">Save Me!</Button>
                 </Prompt><br /><br />
 
-                <Prompt inline={true}>
-                    <Dropdown button={true} buttonColor="alert" placeholder="Remove Me!">
+                <Prompt inline>
+                    <Dropdown button buttonColor="alert" placeholder="Remove Me!">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                     </Dropdown>
                 </Prompt><br /><br />
 
-                <Prompt inline={true}>
+                <Prompt inline>
                     <a>Simple Link</a>
                 </Prompt>
             </div>
@@ -39,7 +39,75 @@ export default class InlineSample extends React.Component {
 
 }`;
 
+const optionalPrompSample = `import React from 'react';
+
+import { Dropdown, Prompt } from 'react-cm-ui';
+
+export default class OptionalPromptSample extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = { showPrompt: false };
+
+        this._onNoClick = this._onNoClick.bind(this);
+        this._onPromptClick = this._onPromptClick.bind(this);
+        this._onYesClick = this._onYesClick.bind(this);
+    }
+
+    render() {
+        return (
+            <Prompt
+                inline
+                inlineMessageColor="alert"
+                message="Delete?"
+                onClick={this._onPromptClick}
+                onNoClick={this._onNoClick}
+                onYesClick={this._onYesClick}
+                show={this.state.showPrompt}
+            >
+                <Dropdown
+                    button
+                    buttonColor="outline"
+                    buttonCompact
+                    collapseMenuOnChange
+                    iconType="ellipsis-h"
+                    theme="dark"
+                >
+                    <Dropdown.Item id="edit" iconInverse iconType="pencil" label="Edit" />
+                    <Dropdown.Item id="delete" iconInverse iconType="trash" label="Delete" />
+                </Dropdown>
+            </Prompt>
+        );
+    }
+
+    _onPromptClick(option) {
+        console.log('Prompt got clicked!  Option:', option);
+
+        if (option.label === 'Delete') {
+            this.setState({ showPrompt: true });
+        }
+
+        // Otherwise handle other option
+    }
+
+    _onYesClick() {
+        console.log('Yes!  Delete it!');
+        this.setState({ showPrompt: false });
+    }
+
+    _onNoClick() {
+        console.log('No ... just kidding.  Don\'t delete it!');
+        this.setState({ showPrompt: false });
+    }
+}`;
+
 export default class ModulesPrompt extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = { showPrompt: false };
+    }
 
     render() {
         const props = [
@@ -111,7 +179,7 @@ export default class ModulesPrompt extends React.Component {
                 </Card>
 
                 {/* Inline */}
-                <Header size="large" style={{ marginTop: '55px' }} sub={true}>
+                <Header anchor="inline" size="large" style={{ marginTop: '55px' }} sub={true}>
                     Inline
                     <Header.Subheader>
                         A Button, Dropdown, or Link can have prompt attached to it asking for a confirmation from the end-user.
@@ -123,7 +191,7 @@ export default class ModulesPrompt extends React.Component {
                 </Prompt><br /><br />
 
                 <Prompt inline={true}>
-                    <Dropdown button={true} buttonColor="alert" placeholder="Remove Me!">
+                    <Dropdown button buttonColor="alert" placeholder="Remove Me!">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                     </Dropdown>
@@ -131,6 +199,47 @@ export default class ModulesPrompt extends React.Component {
 
                 <Prompt inline={true}>
                     <a>Simple Link</a>
+                </Prompt>
+
+                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                    {inlineSample}
+                </Highlighter>
+
+                {/* Dropdown with only some items prompting */}
+                <Header anchor="optional-prompt" size="large" style={{ marginTop: '55px' }} sub={true}>
+                    Optional Prompting for Dropdown
+                    <Header.Subheader>
+                        A Dropdown with an inline prompt attached to it asking for a confirmation from the end-user can
+                        apply this prompt to some items but not others.  This does require some logic in the
+                        <code>onClick</code> handler function and use of the <code>show</code> prop as well.
+                    </Header.Subheader>
+                </Header>
+
+                <p>
+                    Only the <strong>Delete</strong> option in the dropdown menu below should prompt.
+                    The <strong>Edit</strong> option shouldn't prompt.
+                </p>
+
+                <Prompt
+                    inline
+                    inlineMessageColor="alert"
+                    message="Delete?"
+                    onClick={this._onPromptClick.bind(this)}
+                    onNoClick={this._onNoClick.bind(this)}
+                    onYesClick={this._onYesClick.bind(this)}
+                    show={this.state.showPrompt}
+                >
+                    <Dropdown
+                        button
+                        buttonColor="outline"
+                        buttonCompact
+                        collapseMenuOnChange
+                        iconType="ellipsis-h"
+                        theme="dark"
+                    >
+                        <Dropdown.Item id="edit" iconInverse iconType="pencil" label="Edit" />
+                        <Dropdown.Item id="delete" iconInverse iconType="trash" label="Delete" />
+                    </Dropdown>
                 </Prompt>
 
                 <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
@@ -144,4 +253,23 @@ export default class ModulesPrompt extends React.Component {
         console.log('option:', option);
     }
 
+    _onPromptClick(option) {
+        console.log('Prompt got clicked!  Option:', option);
+
+        if (option.label === 'Delete') {
+            this.setState({ showPrompt: true });
+        }
+
+        // Otherwise handle other option
+    }
+
+    _onYesClick() {
+        console.log('Yes!  Delete it!');
+        this.setState({ showPrompt: false });
+    }
+
+    _onNoClick() {
+        console.log('No ... just kidding.  Don\'t delete it!');
+        this.setState({ showPrompt: false });
+    }
 }

--- a/docs/src/js/components/ModulesPrompt.react.js
+++ b/docs/src/js/components/ModulesPrompt.react.js
@@ -84,11 +84,19 @@ export default class OptionalPromptSample extends React.Component {
     _onPromptClick(option) {
         console.log('Prompt got clicked!  Option:', option);
 
-        if (option.label === 'Delete') {
-            this.setState({ showPrompt: true });
-        }
+        switch (option.id) {
+            case 'delete':
+                console.log('Showing delete prompt...');
+                this.setState({ showPrompt: true }); // show the prompt
+                break;
 
-        // Otherwise handle other option
+            case 'edit':
+                console.log('Proceeding with edit action (with no prompt) ...');
+                // TODO: DO whatever edit is supposed to do
+                break;
+
+            // TODO: Handle other options if applicable
+        }
     }
 
     _onYesClick() {
@@ -180,11 +188,17 @@ export default class ModulesPrompt extends React.Component {
 
                 {/* Inline */}
                 <Header anchor="inline" size="large" style={{ marginTop: '55px' }} sub={true}>
-                    Inline
+                    Inline Prompt
                     <Header.Subheader>
                         A Button, Dropdown, or Link can have prompt attached to it asking for a confirmation from the end-user.
                     </Header.Subheader>
                 </Header>
+
+                <p>
+                    Note that the prompt will suppress actions from the wrapped control--button and link <code>onClick</code>,
+                    dropdown <code>onChange</code>, etc.  You handle the <code>Prompt</code> component's events instead
+                    (<code>onClick</code>, <code>onYesClick</code> and <code>onNoClick</code>).
+                </p>
 
                 <Prompt inline={true}>
                     <Button color="success">Save Me!</Button>
@@ -206,18 +220,25 @@ export default class ModulesPrompt extends React.Component {
                 </Highlighter>
 
                 {/* Dropdown with only some items prompting */}
-                <Header anchor="optional-prompt" size="large" style={{ marginTop: '55px' }} sub={true}>
-                    Optional Prompting for Dropdown
+                <Header anchor="selective-prompt" size="large" style={{ marginTop: '55px' }} sub={true}>
+                    Selective Prompting for Dropdown Options
                     <Header.Subheader>
-                        A Dropdown with an inline prompt attached to it asking for a confirmation from the end-user can
-                        apply this prompt to some items but not others.  This does require some logic in the
-                        <code>onClick</code> handler function and use of the <code>show</code> prop as well.
+                        Let's say we have a Dropdown button acting as an action menu with an inline prompt wrapping it,
+                        but we only want <em>certain</em> options to trigger not prompt, not all options (i.e. we need to trigger
+                        the prompt <em>selectively</em>). Note that in the sample above with the dropdown button menu,
+                        the prompt is triggered on <em>all options</em>.
                     </Header.Subheader>
                 </Header>
 
                 <p>
-                    Only the <strong>Delete</strong> option in the dropdown menu below should prompt.
-                    The <strong>Edit</strong> option shouldn't prompt.
+                    In order to achieve selective triggering of the prompt, you will have to add some logic to the
+                    function that handles the prompt's <code>onClick</code> event (where you will switch on the selected
+                    option to determine what to do) and use prompt's <code>show</code> prop to selectively show and hide
+                    the prompt as appropriate.
+                </p>
+                <p>
+                    The example below shows a sample Dropdown button action menu that contains Edit and Delete actions.<br />
+                    Only the <strong>Delete</strong> option should prompt. The <strong>Edit</strong> option shouldn't prompt.
                 </p>
 
                 <Prompt
@@ -243,7 +264,7 @@ export default class ModulesPrompt extends React.Component {
                 </Prompt>
 
                 <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                    {inlineSample}
+                    {optionalPrompSample}
                 </Highlighter>
             </Main>
         );
@@ -256,11 +277,19 @@ export default class ModulesPrompt extends React.Component {
     _onPromptClick(option) {
         console.log('Prompt got clicked!  Option:', option);
 
-        if (option.label === 'Delete') {
-            this.setState({ showPrompt: true });
-        }
+        switch (option.id) {
+            case 'delete':
+                console.log('Showing delete prompt...');
+                this.setState({ showPrompt: true }); // show the prompt
+                break;
 
-        // Otherwise handle other option
+            case 'edit':
+                console.log('Proceeding with edit action (with no prompt) ...');
+                // TODO: DO whatever edit is supposed to do
+                break;
+
+            // TODO: Handle other options if applicable
+        }
     }
 
     _onYesClick() {

--- a/docs/src/js/components/ModulesPrompt.react.js
+++ b/docs/src/js/components/ModulesPrompt.react.js
@@ -24,7 +24,7 @@ export default class InlineSample extends React.Component {
                 </Prompt><br /><br />
 
                 <Prompt inline>
-                    <Dropdown button buttonColor="alert" placeholder="Remove Me!">
+                    <Dropdown button buttonColor="alert" collapseMenuOnChange placeholder="Remove Me!">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                     </Dropdown>
@@ -191,7 +191,7 @@ export default class ModulesPrompt extends React.Component {
                 </Prompt><br /><br />
 
                 <Prompt inline={true}>
-                    <Dropdown button buttonColor="alert" placeholder="Remove Me!">
+                    <Dropdown button buttonColor="alert" collapseMenuOnChange placeholder="Remove Me!">
                         <Dropdown.Item label="Option 1" />
                         <Dropdown.Item label="Option 2" />
                     </Dropdown>

--- a/docs/src/js/components/ModulesPrompt.react.js
+++ b/docs/src/js/components/ModulesPrompt.react.js
@@ -92,7 +92,7 @@ export default class OptionalPromptSample extends React.Component {
 
             case 'edit':
                 console.log('Proceeding with edit action (with no prompt) ...');
-                // TODO: DO whatever edit is supposed to do
+                // TODO: Do whatever edit is supposed to do
                 break;
 
             // TODO: Handle other options if applicable
@@ -285,7 +285,7 @@ export default class ModulesPrompt extends React.Component {
 
             case 'edit':
                 console.log('Proceeding with edit action (with no prompt) ...');
-                // TODO: DO whatever edit is supposed to do
+                // TODO: Do whatever edit is supposed to do
                 break;
 
             // TODO: Handle other options if applicable

--- a/src/Elements/Comment.react.js
+++ b/src/Elements/Comment.react.js
@@ -6,7 +6,9 @@ import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
+import Dropdown from '../Modules/Dropdown.react';
 import Image from './Image.react';
+import Prompt from '../Modules/Prompt.react';
 import TextArea from './TextArea.react';
 
 class Comment extends Component {
@@ -14,22 +16,26 @@ class Comment extends Component {
         super(props);
 
         this.state = {
+            isEditMode: false,
+            showDeleteConfirmation: false,
             updatedCommentText: props.text || '',
-            isEditMode: false
         };
 
         this._onCancelEditClick = this._onCancelEditClick.bind(this);
         this._onCommentChange = this._onCommentChange.bind(this);
-        this._onEditClick = this._onEditClick.bind(this);
+        this._onDeletePromptNoClick = this._onDeletePromptNoClick.bind(this);
+        this._onDeletePromptYesClick = this._onDeletePromptYesClick.bind(this);
         this._onEditKeyDown = this._onEditKeyDown.bind(this);
-        this._onRemoveClick = this._onRemoveClick.bind(this);
+        this._onEditOrDeletePromptClick = this._onEditOrDeletePromptClick.bind(this);
         this._onSaveClick = this._onSaveClick.bind(this);
     }
 
     render() {
-        const { avatarSrc, canEdit, canRemove, children, className, detailsPosition, isEditable, name, style, time } = this.props;
-        const { isEditMode, updatedCommentText } = this.state;
+        const { avatarSrc, canDelete, canEdit, children, className, detailsPosition, isEditable, name, style, time } = this.props;
+        const { isEditMode, showDeleteConfirmation, updatedCommentText } = this.state;
         const containerClasses = ClassNames('ui', 'comment', className);
+        const isRightAligned = detailsPosition === 'right';
+        const editActionMenuAlignment = isRightAligned ? 'left' : 'right';
 
         return (
             <div className={containerClasses} style={style}>
@@ -39,7 +45,7 @@ class Comment extends Component {
                         style={{
                             alignItems: 'center',
                             display: 'flex',
-                            flexDirection: detailsPosition === 'right' ? 'row-reverse' : 'row',
+                            flexDirection: isRightAligned ? 'row-reverse' : 'row',
                             justifyContent: 'flex-start'
                         }}
                     >
@@ -50,59 +56,88 @@ class Comment extends Component {
                         <div
                             style={{
                                 flex: '1 0 auto',
-                                margin: detailsPosition === 'right' ? '0 11px 0 0' : '0 0 0 11px',
-                                textAlign: detailsPosition === 'right' ? 'right' : 'left'
+                                margin: isRightAligned ? '0 11px 0 0' : '0 0 0 11px',
+                                textAlign: isRightAligned ? 'right' : 'left',
                             }}
                         >
                             <span className="comment-name">{name}</span>
                             <span className="comment-time">{this._renderTime()}</span>
                         </div>
-                        { isEditable && (canEdit || canRemove) ?
+                        { isEditable && (canEdit || canDelete) ?
                             isEditMode ? (
                                 <div
                                     style={{
                                         flex: '1 0 auto',
-                                        margin: detailsPosition === 'right' ? '0 0 0 11px' : '0 11px 0 0',
-                                        textAlign: detailsPosition === 'right' ? 'left' : 'right'
+                                        margin: 0,
+                                        paddingTop: '19px',
+                                        textAlign: editActionMenuAlignment
                                     }}
                                 >
                                     <a
-                                        className="cancel-link"
+                                        className="cancel-link font-size-xsmall color-text"
                                         onClick={this._onCancelEditClick}
-                                        style={{ marginRight: '11px' }}
+                                        style={{ display: 'inline-block' }}
                                     >
                                         {'Cancel'}
                                     </a>
                                     <a
-                                        className="save-link"
+                                        className="save-link font-size-xsmall"
                                         disabled={!canEdit}
                                         onClick={this._onSaveClick}
-                                        style={{ marginRight: '11px' }}
+                                        style={{ display: 'inline-block', marginLeft: '22px' }}
                                     >
                                         {'Save'}
-                                    </a>
-                                    <a
-                                        className="remove-link"
-                                        disabled={!canRemove}
-                                        onClick={this._onRemoveClick}
-                                    >
-                                        {'Remove'}
                                     </a>
                                 </div>
                             ) : (
                                 <div
                                     style={{
                                         flex: '1 0 auto',
-                                        margin: detailsPosition === 'right' ? '0 0 0 11px' : '0 11px 0 0',
-                                        textAlign: detailsPosition === 'right' ? 'left' : 'right'
+                                        margin: 0,
+                                        textAlign: editActionMenuAlignment
                                     }}
                                 >
-                                    <a
-                                        className="edit-link"
-                                        onClick={this._onEditClick}
+                                    <Prompt
+                                        inline
+                                        inlineHorizontalAlign={isRightAligned ? 'left' : 'right'}
+                                        inlineMessageColor="alert"
+                                        message={'Delete?'}
+                                        onClick={this._onEditOrDeletePromptClick}
+                                        onNoClick={this._onDeletePromptNoClick}
+                                        onYesClick={this._onDeletePromptYesClick}
+                                        show={showDeleteConfirmation}
                                     >
-                                        {'Edit'}
-                                    </a>
+                                        <Dropdown
+                                            button
+                                            buttonColor="transparent"
+                                            buttonCompact
+                                            collapseMenuOnChange
+                                            iconColor="static"
+                                            iconPosition="right"
+                                            iconType="ellipsis-h"
+                                            style={{ margin: 0, padding: 0  }}
+                                            theme="dark"
+                                        >
+                                            { canEdit ? (
+                                                <Dropdown.Item
+                                                    className="action-edit"
+                                                    iconInverse
+                                                    iconType="pencil"
+                                                    id="edit"
+                                                    label={'Edit'}
+                                                />
+                                            ) : null}
+                                            { canDelete ? (
+                                                <Dropdown.Item
+                                                    className="action-delete"
+                                                    iconInverse
+                                                    iconType="trash"
+                                                    id="delete"
+                                                    label={'Delete'}
+                                                />
+                                            ) : null}
+                                        </Dropdown>
+                                    </Prompt>
                                 </div>
                                 ) :
                             null
@@ -126,15 +161,38 @@ class Comment extends Component {
     }
 
     _onCancelEditClick() {
-        this.setState({ isEditMode: false });
+        this.setState({
+            isEditMode: false,
+            updatedCommentText: this.props.text || ''
+        });
     }
 
     _onCommentChange(value) {
         this.setState({ updatedCommentText: value });
     }
 
-    _onEditClick() {
-        this.setState({ isEditMode: true });
+    _onDeletePromptNoClick() {
+        this.setState({ showDeleteConfirmation: false });
+    }
+
+    _onDeletePromptYesClick() {
+        const { onDelete } = this.props;
+        if (_.isFunction(onDelete)) {
+            onDelete();
+        }
+
+        this.setState({ showDeleteConfirmation: false });
+    }
+
+    _onEditOrDeletePromptClick(selectedOption) {
+        switch (selectedOption.id) {
+            case 'delete':
+                this.setState({ showDeleteConfirmation: true });
+                break;
+            case 'edit':
+                this.setState({ isEditMode: true });
+                break;
+        }
     }
 
     _onEditKeyDown(event) {
@@ -142,15 +200,6 @@ class Comment extends Component {
             event.preventDefault();
             this._onSaveClick();
         }
-    }
-
-    _onRemoveClick() {
-        const { onRemove } = this.props;
-        if (_.isFunction(onRemove)) {
-            onRemove();
-        }
-
-        this.setState({ isEditMode: false });
     }
 
     _onSaveClick() {
@@ -178,13 +227,13 @@ class Comment extends Component {
 
 Comment.propTypes = {
     avatarSrc: PropTypes.string,
+    canDelete: PropTypes.bool,
     canEdit: PropTypes.bool,
-    canRemove: PropTypes.bool,
     className: PropTypes.string,
     detailsPosition: PropTypes.oneOf([ 'left', 'right' ]),
     isEditable: PropTypes.bool,
     name: PropTypes.string,
-    onRemove: PropTypes.func,
+    onDelete: PropTypes.func,
     onSaveEdit: PropTypes.func,
     style: PropTypes.object,
     text: PropTypes.string,
@@ -192,8 +241,8 @@ Comment.propTypes = {
 };
 
 Comment.defaultProps = {
+    canDelete: false,
     canEdit: false,
-    canRemove: false,
     detailsPosition: 'left',
     isEditable: false
 }

--- a/src/Elements/Comment.react.js
+++ b/src/Elements/Comment.react.js
@@ -1,15 +1,34 @@
 'use strict';
 
+import _ from 'lodash';
 import ClassNames from 'classnames';
 import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import Image from './Image.react';
+import TextArea from './TextArea.react';
 
 class Comment extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            updatedCommentText: props.text || '',
+            isEditMode: false
+        };
+
+        this._onCancelEditClick = this._onCancelEditClick.bind(this);
+        this._onCommentChange = this._onCommentChange.bind(this);
+        this._onEditClick = this._onEditClick.bind(this);
+        this._onEditKeyDown = this._onEditKeyDown.bind(this);
+        this._onRemoveClick = this._onRemoveClick.bind(this);
+        this._onSaveClick = this._onSaveClick.bind(this);
+    }
+
     render() {
-        const { avatarSrc, children, className, detailsPosition, name, style, time } = this.props;
+        const { avatarSrc, canEdit, canRemove, children, className, detailsPosition, isEditable, name, style, time } = this.props;
+        const { isEditMode, updatedCommentText } = this.state;
         const containerClasses = ClassNames('ui', 'comment', className);
 
         return (
@@ -38,14 +57,109 @@ class Comment extends Component {
                             <span className="comment-name">{name}</span>
                             <span className="comment-time">{this._renderTime()}</span>
                         </div>
+                        { isEditable && (canEdit || canRemove) ?
+                            isEditMode ? (
+                                <div
+                                    style={{
+                                        flex: '1 0 auto',
+                                        margin: detailsPosition === 'right' ? '0 0 0 11px' : '0 11px 0 0',
+                                        textAlign: detailsPosition === 'right' ? 'left' : 'right'
+                                    }}
+                                >
+                                    <a
+                                        className="cancel-link"
+                                        onClick={this._onCancelEditClick}
+                                        style={{ marginRight: '11px' }}
+                                    >
+                                        {'Cancel'}
+                                    </a>
+                                    <a
+                                        className="save-link"
+                                        disabled={!canEdit}
+                                        onClick={this._onSaveClick}
+                                        style={{ marginRight: '11px' }}
+                                    >
+                                        {'Save'}
+                                    </a>
+                                    <a
+                                        className="remove-link"
+                                        disabled={!canRemove}
+                                        onClick={this._onRemoveClick}
+                                    >
+                                        {'Remove'}
+                                    </a>
+                                </div>
+                            ) : (
+                                <div
+                                    style={{
+                                        flex: '1 0 auto',
+                                        margin: detailsPosition === 'right' ? '0 0 0 11px' : '0 11px 0 0',
+                                        textAlign: detailsPosition === 'right' ? 'left' : 'right'
+                                    }}
+                                >
+                                    <a
+                                        className="edit-link"
+                                        onClick={this._onEditClick}
+                                    >
+                                        {'Edit'}
+                                    </a>
+                                </div>
+                                ) :
+                            null
+                        }
                     </div>
                 ) : null}
 
                 <div className="comment-bubble">
-                    {children}
+                    {isEditable && canEdit && isEditMode ? (
+                        <TextArea
+                            fluid
+                            onChange={this._onCommentChange}
+                            onKeyDown={this._onEditKeyDown}
+                            ref={ref => this.editableCommentTextArea = ref}
+                            value={updatedCommentText}
+                        />
+                    ): children}
                 </div>
             </div>
         );
+    }
+
+    _onCancelEditClick() {
+        this.setState({ isEditMode: false });
+    }
+
+    _onCommentChange(value) {
+        this.setState({ updatedCommentText: value });
+    }
+
+    _onEditClick() {
+        this.setState({ isEditMode: true });
+    }
+
+    _onEditKeyDown(event) {
+        if (event.keyCode === 13 && !event.shiftKey) {
+            event.preventDefault();
+            this._onSaveClick();
+        }
+    }
+
+    _onRemoveClick() {
+        const { onRemove } = this.props;
+        if (_.isFunction(onRemove)) {
+            onRemove();
+        }
+
+        this.setState({ isEditMode: false });
+    }
+
+    _onSaveClick() {
+        const { onSaveEdit } = this.props;
+        if (_.isFunction(onSaveEdit)) {
+            onSaveEdit(this.editableCommentTextArea.textArea.value);
+        }
+
+        this.setState({ isEditMode: false });
     }
 
     _renderTime() {
@@ -64,11 +178,24 @@ class Comment extends Component {
 
 Comment.propTypes = {
     avatarSrc: PropTypes.string,
+    canEdit: PropTypes.bool,
+    canRemove: PropTypes.bool,
     className: PropTypes.string,
     detailsPosition: PropTypes.oneOf([ 'left', 'right' ]),
+    isEditable: PropTypes.bool,
     name: PropTypes.string,
+    onRemove: PropTypes.func,
+    onSaveEdit: PropTypes.func,
     style: PropTypes.object,
+    text: PropTypes.string,
     time: PropTypes.number
 };
+
+Comment.defaultProps = {
+    canEdit: false,
+    canRemove: false,
+    detailsPosition: 'left',
+    isEditable: false
+}
 
 export default Comment;

--- a/src/Elements/Comment.react.js
+++ b/src/Elements/Comment.react.js
@@ -36,6 +36,7 @@ class Comment extends Component {
         const containerClasses = ClassNames('ui', 'comment', className);
         const isRightAligned = detailsPosition === 'right';
         const editActionMenuAlignment = isRightAligned ? 'left' : 'right';
+        const editMenuTitle = (canDelete && canEdit) ? 'Edit or Delete' : canEdit ? 'Edit' : canDelete ? 'Delete' : null;
 
         return (
             <div className={containerClasses} style={style}>
@@ -99,7 +100,7 @@ class Comment extends Component {
                                 >
                                     <Prompt
                                         inline
-                                        inlineHorizontalAlign={isRightAligned ? 'left' : 'right'}
+                                        inlineHorizontalAlign={editActionMenuAlignment}
                                         inlineMessageColor="alert"
                                         message={'Delete?'}
                                         onClick={this._onEditOrDeletePromptClick}
@@ -114,6 +115,7 @@ class Comment extends Component {
                                             collapseMenuOnChange
                                             iconColor="static"
                                             iconPosition="right"
+                                            iconTitle={editMenuTitle}
                                             iconType="ellipsis-h"
                                             style={{ margin: 0, padding: 0  }}
                                             theme="dark"

--- a/src/Modules/Dropdown.react.js
+++ b/src/Modules/Dropdown.react.js
@@ -72,12 +72,14 @@ class Dropdown extends Component {
     render() {
         const { button, buttonColor, buttonCompact, children,
             className, clearable, disable, fluid, iconColor,
-            iconInverse, iconPosition, iconSize, iconType, inverse, label, labelStyle,
-            options, placeholder, searchable, selection,
-            selectionCreatable, selectionMenuContainerStyle, selectionMenuStyle,
-            selectionMobile, selectionOptionComponent, selectionValueComponent, selectionMultiple, selectionRequired,
+            iconInverse, iconPosition, iconSize, iconTitle, iconType,
+            inverse, label, labelStyle, options, placeholder, searchable,
+            selection, selectionCreatable, selectionMenuContainerStyle,
+            selectionMenuStyle, selectionMobile, selectionOptionComponent,
+            selectionValueComponent, selectionMultiple, selectionRequired,
             selectionUnderline, style, tabIndex, text, theme } = this.props;
         const { menuIsOpen, menuPositionStyle } = this.state;
+        const dropdownIconTitle = iconTitle || placeholder || text;
         const isButtonDisabled = buttonColor === 'disable';
         const containerClasses = ClassNames('ui', 'dropdown', className, {
             'dropdown-button': button,
@@ -135,7 +137,7 @@ class Dropdown extends Component {
                             key={'dropdown-menu-item-' + index}
                         >
                             <span onClick={this._onDropdownMenuItemClick.bind(this, value)}>
-                                {iconType ? <Icon inverse={iconInverse} color={iconColor} type={iconType} /> : null}
+                                {iconType ? <Icon inverse={iconInverse} color={iconColor} title={value.label} type={iconType} /> : null}
                                 {value.label}
                             </span>
                         </li>
@@ -170,7 +172,7 @@ class Dropdown extends Component {
                                                 <span className="label">{this.state.value.label}</span>
                                             )}
 
-                                            <Icon color={disable ? 'disable' : null} compact type="arrows-alt" />
+                                            <Icon color={disable ? 'disable' : null} compact title={dropdownIconTitle} type="arrows-alt" />
                                         </div>
 
                                         <Modal
@@ -198,6 +200,7 @@ class Dropdown extends Component {
                                                         <Icon
                                                             compact={true}
                                                             size={selectionUnderline ? 10 : 16}
+                                                            title={dropdownIconTitle}
                                                             type={iconType ? iconType : selectionUnderline ? 'caret-down' : 'chevron-down'}
                                                         />
                                                     </div>
@@ -209,6 +212,7 @@ class Dropdown extends Component {
                                                         <Icon
                                                             compact
                                                             size={selectionUnderline ? 10 : 16}
+                                                            title={'Clear Selection'}
                                                             type="times"
                                                         />
                                                     </div>
@@ -250,14 +254,14 @@ class Dropdown extends Component {
                             arrowRenderer={() => {
                                 return (
                                     <div>
-                                        <Icon compact size={16} type="chevron-down" />
+                                        <Icon compact size={16} title={dropdownIconTitle} type="chevron-down" />
                                     </div>
                                 );
                             }}
                             clearRenderer={() => {
                                 return (
                                     <div>
-                                        <Icon compact size={16} type="times" />
+                                        <Icon compact size={16} title={'Clear Selection'} type="times" />
                                     </div>
                                 );
                             }}
@@ -297,6 +301,7 @@ class Dropdown extends Component {
                         color={this.state.menuIsOpen && !button ? 'highlight' : button ? iconColor || null : null}
                         inverse={iconInverse}
                         size={iconSize || 'small'}
+                        title={dropdownIconTitle}
                         type={iconType || 'chevron-down'}
                     />
                 ) : null}
@@ -315,6 +320,7 @@ class Dropdown extends Component {
                         compact
                         inverse={iconInverse}
                         size={iconSize || 'small'}
+                        title={dropdownIconTitle}
                         type={iconType || 'chevron-down'}
                     />
                 ) : null}
@@ -552,6 +558,7 @@ Dropdown.propTypes = {
         PropTypes.oneOf(Utils.sizeEnums()),
         PropTypes.number
     ]),
+    iconTitle: PropTypes.string,
     iconType: PropTypes.string,
     inverse: PropTypes.bool,
     label: PropTypes.string,

--- a/src/Modules/Dropdown.react.js
+++ b/src/Modules/Dropdown.react.js
@@ -60,12 +60,12 @@ class Dropdown extends Component {
         this._onDropdownMenuResize = this._onDropdownMenuResize.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (!_.isEqual(this.props, nextProps)) {
-            this.setState({
-                menuIsOpen: !_.isEqual(this.props.value, nextProps.value),
-                value: nextProps.value
-            });
+    componentDidUpdate(prevProps) {
+        const { value: currentPropsValue } = this.props;
+        const { value: previousPropsValue } = prevProps;
+
+        if (!_.isEqual(currentPropsValue, previousPropsValue)) {
+            this.setState({ menuIsOpen: false, value: currentPropsValue });
         }
     }
 
@@ -395,10 +395,22 @@ class Dropdown extends Component {
     }
 
     _onChange(selectedOption) {
-        if (!_.isUndefined(this.props.onChange)) {
-            this.props.onChange(selectedOption);
+        const { collapseMenuOnChange, onChange } = this.props;
+
+        if (!_.isUndefined(onChange)) {
+            onChange(selectedOption);
+
+            if (collapseMenuOnChange) {
+                this.setState({ menuIsOpen: false });
+            }
         } else {
-            this.setState({ value: selectedOption });
+            const updatedState = { value: selectedOption };
+
+            if (collapseMenuOnChange) {
+                updatedState.menuIsOpen = false;
+            }
+
+            this.setState(updatedState);
         }
     }
 
@@ -519,16 +531,9 @@ class Dropdown extends Component {
 
         return items;
     }
-
-    _valueRenderer() {
-
-    }
-
 }
 
 Dropdown.Item = DropdownItem;
-
-
 
 Dropdown.propTypes = {
     button: PropTypes.bool,
@@ -536,6 +541,7 @@ Dropdown.propTypes = {
     buttonCompact: PropTypes.bool,
     className: PropTypes.string,
     clearable: PropTypes.bool,
+    collapseMenuOnChange: PropTypes.bool,
     disable: PropTypes.bool,
     fluid: PropTypes.bool,
     iconColor: PropTypes.oneOf(Utils.colorEnums()),

--- a/src/Modules/Dropdown.react.js
+++ b/src/Modules/Dropdown.react.js
@@ -91,6 +91,7 @@ class Dropdown extends Component {
             'dropdown-color-alternate': buttonColor === 'alternate',
             'dropdown-color-secondary': buttonColor === 'secondary',
             'dropdown-color-success': buttonColor === 'success',
+            'dropdown-color-transparent': buttonColor === 'transparent',
             'dropdown-color-warning': buttonColor === 'warning',
             'dropdown-disable': disable,
             'dropdown-fluid': fluid,
@@ -293,7 +294,7 @@ class Dropdown extends Component {
             >
                 {iconPosition === 'left' ? (
                     <Icon
-                        color={this.state.menuIsOpen && !button ? 'highlight' : null}
+                        color={this.state.menuIsOpen && !button ? 'highlight' : button ? iconColor || null : null}
                         inverse={iconInverse}
                         size={iconSize || 'small'}
                         type={iconType || 'chevron-down'}
@@ -310,7 +311,7 @@ class Dropdown extends Component {
 
                 {!iconPosition || iconPosition === 'right' ? (
                     <Icon
-                        color={this.state.menuIsOpen && !button ? 'highlight' : null}
+                        color={this.state.menuIsOpen && !button ? 'highlight' : button ? iconColor || null : null}
                         compact
                         inverse={iconInverse}
                         size={iconSize || 'small'}
@@ -547,7 +548,10 @@ Dropdown.propTypes = {
     iconColor: PropTypes.oneOf(Utils.colorEnums()),
     iconInverse: PropTypes.bool,
     iconPosition: PropTypes.oneOf([ 'left', 'right' ]),
-    iconSize: PropTypes.oneOf(Utils.sizeEnums()),
+    iconSize: PropTypes.oneOfType([
+        PropTypes.oneOf(Utils.sizeEnums()),
+        PropTypes.number
+    ]),
     iconType: PropTypes.string,
     inverse: PropTypes.bool,
     label: PropTypes.string,

--- a/src/Modules/Prompt.react.js
+++ b/src/Modules/Prompt.react.js
@@ -119,7 +119,7 @@ class Prompt extends Component {
         } else if (children && children.type.name === 'Dropdown') {
             return React.cloneElement(children, {
                 className: promptActionClasses,
-                buttonColor: show ? 'disable' : children.props.buttonColor,
+                buttonColor: show && children.props.buttonColor !== 'transparent' ? 'disable' : children.props.buttonColor,
                 onChange: this._onClick.bind(this),
                 ref: promptAction => { this.promptAction = promptAction }
             });

--- a/src/scss/components/Modules/Dropdown.scss
+++ b/src/scss/components/Modules/Dropdown.scss
@@ -271,7 +271,7 @@ $select-item-disabled-border-color: darken($select-item-disabled-bg, 10%) !defau
         &.dropdown-is-active {
             background-color: $bkgd-highlight;
             color: $color-text-inverse;
-            > .ui.icon .icon-use-path { fill: $color-text-inverse; }
+            &:not(.dropdown-color-transparent) > .ui.icon .icon-use-path { fill: $color-text-inverse; }
             &.dropdown-color-disable {
                 background-color: $bkgd-button-disable !important;
                 color: $color-text-static;
@@ -283,6 +283,11 @@ $select-item-disabled-border-color: darken($select-item-disabled-bg, 10%) !defau
                 box-shadow: inset 0 0 0 1px $border-highlight;
                 color: $color-text;
                 > .ui.icon .icon-use-path { fill: $color-text; }
+            }
+            &.dropdown-color-transparent {
+                background-color: transparent;
+                color: $color-text;
+                > .ui.icon.icon-color-primary .icon-use-path { fill: $color-text; }
             }
         }
         &.dropdown-inverse.dropdown-color- {

--- a/src/scss/components/Modules/Dropdown.scss
+++ b/src/scss/components/Modules/Dropdown.scss
@@ -259,6 +259,10 @@ $select-item-disabled-border-color: darken($select-item-disabled-bg, 10%) !defau
                 background-color: $bkgd-button-success;
                 > .ui.icon .icon-use-path { fill: $color-text-inverse; }
             }
+            &transparent {
+                background-color: transparent;
+                > .ui.icon.icon-color-primary .icon-use-path { fill: $color-text; }
+            }
             &warning {
                 background-color: $bkgd-warning;
                 > .ui.icon .icon-use-path { fill: $color-text-inverse; }


### PR DESCRIPTION
Add ability to edit and delete comments using the Comment component
Being done in service of Workflows 1.0 User Task Dashboard
[PBI 11063](https://saddlebackchurch.visualstudio.com/DefaultCollection/Church%20Management/_workitems/edit/11063): Ability to leave a comment on a task
[Task 12380](https://saddlebackchurch.visualstudio.com/DefaultCollection/Church%20Management/_workitems/edit/12380): BUG: My Dashboard > Task Details Drawer: Cannot edit/delete comments
Sketch: https://sketch.cloud/s/ORzY2/Pr3OEv
Requirements: https://saddleback.egnyte.com/dl/YoLk2mpHTO

Let's please use this PR as a discussion forum to dial the basic UI/UX of the Comment component.  Then we'll work on the specific placement of the component in the My Dashboard Task Drawer.

* Comment author can edit and/or delete own comments
* Task supervisor can delete anyone's comments

The React CM UI library component will not attempt to make any assumptions about these kinds of "permissions" -- instead the consumer sets props indicating what actions are and are not allowed.

![image](https://user-images.githubusercontent.com/4349658/47604781-04573e80-d9b3-11e8-9856-29d40e04b21c.png)

![image](https://user-images.githubusercontent.com/4349658/47604786-176a0e80-d9b3-11e8-9d09-9662c009486e.png)

![image](https://user-images.githubusercontent.com/4349658/47604787-1df88600-d9b3-11e8-80eb-62e874c26145.png)

(Banner is not baked in -- it is just for illustrative purposes on the documentation page.  Component simply calls an `onSaveEdit()` prop function provided by the consumer, allowing the consumer to issue API calls, show banners, whatever to save the comment and inform the user it's done.)