### PR TITLE
[dev] [part of] PBI [14321] Add DurationPicker component (will be used for Follow Up (Task) Due Date policy)

### DIFF
--- a/docs/src/js/components/CoreApp.react.js
+++ b/docs/src/js/components/CoreApp.react.js
@@ -335,6 +335,14 @@ let routes = (
                 }}
             />
             <Route
+                path="duration-picker"
+                getComponent={(location, callback) => {
+                    require.ensure([], require => {
+                        callback(null, require('components/ModulesDurationPicker.react'))
+                    }, 'ModulesDurationPicker')
+                }}
+            />
+            <Route
                 path="modal"
                 getComponent={(location, callback) => {
                     require.ensure([], require => {

--- a/docs/src/js/components/CoreAppNavigation.react.js
+++ b/docs/src/js/components/CoreAppNavigation.react.js
@@ -179,6 +179,9 @@ export default class CoreAppNavigation extends React.Component {
                             <li>
                                 <Link className="core-app-nav-item" to={{ pathname: '/modules/dropdown' }} activeClassName={isActive}>Dropdown</Link>
                             </li>
+                            <li>
+                                <Link className="core-app-nav-item" to={{ pathname: '/modules/duration-picker' }} activeClassName={isActive}>Duration Picker</Link>
+                            </li>
 
                             <li>
                                 <Link className="core-app-nav-item" className="core-app-nav-item" to={{ pathname: '/modules/modal' }} activeClassName={isActive}>Modal</Link>

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -257,7 +257,7 @@ export default class ModulesDurationPicker extends React.Component {
                     value={this.state.value1}
                 />
 
-            <p>You can use the <code>showXXX</code> props to include or exclude various units of time.</p>
+                <p>You can use the <code>showXXX</code> props to include or exclude various units of time.</p>
 
                 <DurationPicker
                     showMinutes

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -1,0 +1,352 @@
+'use strict';
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Card, DurationPicker, Header, TitleBar } from 'react-cm-ui';
+
+// Docs UI Components
+import Block from 'components/UI/Block.react';
+import Highlighter from 'components/UI/Highlighter.react';
+import Main from 'components/UI/Main.react';
+import TableProps from 'components/UI/TableProps.react';
+
+const durationPickerSample = `import moment from 'moment'; // or moment-timezone
+import React from 'react';
+
+import { DurationPicker } from 'react-cm-ui';
+
+export default class DurationPickerSample extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = { value1: null, value2: null };
+        this._onDurationPicker1Change = this._onDurationPicker1Change.bind(this);
+        this._onDurationPicker2Change = this._onDurationPicker2Change.bind(this);
+    }
+
+    render() {
+        return (
+            <div>
+                <DurationPicker
+                    id="duration-picker-1"
+                    onChange={this._onDurationPicker1Change}
+                    value={this.state.value1}
+                />
+
+                <DurationPicker
+                    id="duration-picker-2"
+                    showMinutes
+                    showSeconds
+                    onChange={this._onDurationPicker2Change}
+                    value={this.state.value2}
+                />
+
+                <DurationPicker
+                    id="duration-picker-3"
+                    showHours={false}
+                    showMonths
+                    showYears
+                    onChange={this._onDurationPicker3Change}
+                    value={this.state.value3}
+                />
+            </div>
+        );
+    }
+
+    _onDurationPicker1Change(value) {
+        this.setState({ value1: value });
+    }
+
+    _onDurationPicker2Change(value) {
+        this.setState({ value2: value });
+    }
+
+    _onDurationPicker3Change(value) {
+        this.setState({ value3: value });
+    }
+}`;
+
+const disabledSample = `import moment from 'moment'; // or moment-timezone
+import React from 'react';
+
+import { DurationPicker } from 'react-cm-ui';
+
+export default class DisabledDurationPickerSample extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = { value: null };
+        this._onDurationPickerChange = this._onDurationPickerChange.bind(this);
+    }
+
+    render() {
+        return (
+            <DurationPicker
+                disabled
+                id="disabled-duration-picker"
+                onChange={this._onDurationPickerChange}
+                value={this.state.value}
+            />
+        );
+    }
+
+    _onDurationPickerChange(value) {
+        this.setState({ value });
+    }
+}`;
+
+const nestSample =`import moment from 'moment'; // or moment-timezone
+import React from 'react';
+
+import { DurationPicker } from 'react-cm-ui';
+
+export default class NestedDurationPickerSample extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = { value: null };
+        this._onDurationPickerChange = this._onDurationPickerChange.bind(this);
+    }
+
+    render() {
+        return (
+            <div className="some-class-that-has-nested-bkgd-color">
+                <DurationPicker
+                    id="nested-duration-picker"
+                    nest
+                    onChange={this._onDurationPickerChange}
+                    value={this.state.value}
+                />
+            </div>
+        );
+    }
+
+    _onDurationPickerChange(value) {
+        this.setState({ value: value });
+    }
+}`;
+
+export default class ModulesDurationPicker extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            value1: null,
+            value2: null,
+            value3: null,
+            value4: null,
+            value5: null
+        };
+
+        this._onDurationPicker1Change = this._onDurationPicker1Change.bind(this);
+        this._onDurationPicker2Change = this._onDurationPicker2Change.bind(this);
+        this._onDurationPicker3Change = this._onDurationPicker3Change.bind(this);
+        this._onDurationPicker4Change = this._onDurationPicker4Change.bind(this);
+        this._onDurationPicker5Change = this._onDurationPicker5Change.bind(this);
+    }
+
+    render() {
+        const props = [
+            {
+                name: 'className',
+                type: 'string',
+                default: '',
+                description: 'Additional classes.',
+                allowedTypes: ''
+            }, {
+                name: 'disabled',
+                type: 'bool',
+                default: '',
+                description: 'Indicates that the Time Span Picker is not available for interaction.',
+                allowedTypes: ''
+            }, {
+                name: 'error',
+                type: 'bool || string',
+                default: '',
+                description: 'Indicates that the Time Span Picker has an error.',
+                allowedTypes: ''
+            }, {
+                name: 'id',
+                type: 'string',
+                default: '',
+                description: 'Give the Time Span Picker input an id.',
+                allowedTypes: ''
+            }, {
+                name: 'label',
+                type: 'string',
+                default: '',
+                description: 'Optional Label to display on top of the Time Span Picker.',
+                allowedTypes: ''
+            }, {
+                name: 'nest',
+                type: 'bool',
+                default: '',
+                description: 'Time Span Picker may be placed in a nested background color.',
+                allowedTypes: ''
+            }, {
+                name: 'onChange',
+                type: 'func',
+                default: '',
+                description: 'Can handle an onChange event from parent.',
+                allowedTypes: ''
+            }, {
+                name: 'required',
+                type: 'bool',
+                default: '',
+                description: 'Specifies that the user must fill in a value before submitting a form.',
+                allowedTypes: ''
+            }, {
+                name: 'showDays',
+                type: 'bool',
+                default: 'true',
+                description: 'Specifies whether or not the Duration Picker should include a Days input.',
+                allowedTypes: ''
+            }, {
+                name: 'showHours',
+                type: 'bool',
+                default: 'true',
+                description: 'Specifies whether or not the Duration Picker should include a Hours input.',
+                allowedTypes: ''
+            }, {
+                name: 'showMinutes',
+                type: 'bool',
+                default: 'false',
+                description: 'Specifies whether or not the Duration Picker should include a Minutes input.',
+                allowedTypes: ''
+            }, {
+                name: 'showMonths',
+                type: 'bool',
+                default: 'false',
+                description: 'Specifies whether or not the Duration Picker should include a Months input.',
+                allowedTypes: ''
+            }, {
+                name: 'showSeconds',
+                type: 'bool',
+                default: 'false',
+                description: 'Specifies whether or not the Duration Picker should include a Seconds input.',
+                allowedTypes: ''
+            }, {
+                name: 'showYears',
+                type: 'bool',
+                default: 'false',
+                description: 'Specifies whether or not the Duration Picker should include a Years input.',
+                allowedTypes: ''
+            }, {
+                name: 'value',
+                type: 'object',
+                default: '',
+                description: 'The initial value of the control.',
+                allowedTypes: ''
+            }
+        ];
+
+        return (
+            <Main page="headers">
+                <TitleBar title="Duration Picker" />
+
+                <Card>
+                    <Header size="large">Props</Header>
+
+                    <TableProps props={props} />
+                </Card>
+
+                {/* Duration Picker */}
+                <Header size="large" style={{ marginTop: '55px' }} sub>
+                    Duration Picker
+                    <Header.Subheader>
+                        A basic Duration Picker.
+                    </Header.Subheader>
+                </Header>
+
+                <DurationPicker
+                    onChange={this._onDurationPicker1Change}
+                    value={this.state.value1}
+                />
+
+            <p>You can use the <code>showXXX</code> props to include or exclude various units of time.</p>
+
+                <DurationPicker
+                    showMinutes
+                    showSeconds
+                    onChange={this._onDurationPicker2Change}
+                    value={this.state.value2}
+                />
+
+                <br />
+                
+                <DurationPicker
+                    showHours={false}
+                    showMonths
+                    showYears
+                    onChange={this._onDurationPicker3Change}
+                    value={this.state.value3}
+                />
+
+                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                    {durationPickerSample}
+                </Highlighter>
+
+                {/* Disabled */}
+                <Header size="large" style={{ marginTop: '55px' }} sub>
+                    Disabled
+                    <Header.Subheader>
+                        The <code>disabled</code> prop indicates that the Duration Picker is not available for interaction.
+                    </Header.Subheader>
+                </Header>
+
+                <DurationPicker
+                    disabled
+                    onChange={this._onDuration4PickerChange}
+                    value={this.state.value4}
+                />
+
+                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                    {disabledSample}
+                </Highlighter>
+
+                {/* Nest */}
+                <Header size="large" style={{ marginTop: '55px' }} sub>
+                    Nest
+                    <Header.Subheader>
+                        A Duration Picker can give the appearance of being nested. The parent's background color needs to be set to <code>$bkgd-nest</code>.
+                    </Header.Subheader>
+                </Header>
+
+                <Block
+                    nest
+                    style={{ height: '175px', padding: '22px' }}
+                >
+                    <DurationPicker
+                        nest
+                        onChange={this._onDurationPicker5Change}
+                        value={this.state.value5}
+                    />
+                </Block>
+
+                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
+                    {nestSample}
+                </Highlighter>
+            </Main>
+        );
+    }
+
+    _onDurationPicker1Change(newValue) {
+        this.setState({ value1: newValue });
+    }
+
+    _onDurationPicker2Change(newValue) {
+        this.setState({ value2: newValue });
+    }
+
+    _onDurationPicker3Change(newValue) {
+        this.setState({ value3: newValue });
+    }
+
+    _onDurationPicker4Change(newValue) {
+        this.setState({ value4: newValue });
+    }
+
+    _onDurationPicker5Change(newValue) {
+        this.setState({ value5: newValue });
+    }
+}

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -157,31 +157,31 @@ export default class ModulesDurationPicker extends React.Component {
                 name: 'disabled',
                 type: 'bool',
                 default: '',
-                description: 'Indicates that the Time Span Picker is not available for interaction.',
+                description: 'Indicates that the Duration Picker is not available for interaction.',
                 allowedTypes: ''
             }, {
                 name: 'error',
                 type: 'bool || string',
                 default: '',
-                description: 'Indicates that the Time Span Picker has an error.',
+                description: 'Indicates that the Duration Picker has an error.',
                 allowedTypes: ''
             }, {
                 name: 'id',
                 type: 'string',
                 default: '',
-                description: 'Give the Time Span Picker input an id.',
+                description: 'Give the Duration Picker input an id.',
                 allowedTypes: ''
             }, {
                 name: 'label',
                 type: 'string',
                 default: '',
-                description: 'Optional Label to display on top of the Time Span Picker.',
+                description: 'Optional Label to display on top of the Duration Picker.',
                 allowedTypes: ''
             }, {
                 name: 'nest',
                 type: 'bool',
                 default: '',
-                description: 'Time Span Picker may be placed in a nested background color.',
+                description: 'Duration Picker may be placed in a nested background color.',
                 allowedTypes: ''
             }, {
                 name: 'onChange',
@@ -273,7 +273,7 @@ export default class ModulesDurationPicker extends React.Component {
                 />
 
                 <br />
-                
+
                 <DurationPicker
                     showHours={false}
                     showMonths

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -171,13 +171,7 @@ export default class ModulesDurationPicker extends React.Component {
                 default: '',
                 description: 'Give the Duration Picker input an id.',
                 allowedTypes: ''
-            }, {
-                name: 'label',
-                type: 'string',
-                default: '',
-                description: 'Optional Label to display on top of the Duration Picker.',
-                allowedTypes: ''
-            }, {
+            }{
                 name: 'nest',
                 type: 'bool',
                 default: '',

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -171,7 +171,7 @@ export default class ModulesDurationPicker extends React.Component {
                 default: '',
                 description: 'Give the Duration Picker input an id.',
                 allowedTypes: ''
-            }{
+            }, {
                 name: 'nest',
                 type: 'bool',
                 default: '',

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -227,7 +227,7 @@ export default class ModulesDurationPicker extends React.Component {
                 allowedTypes: ''
             }, {
                 name: 'value',
-                type: 'object',
+                type: 'object (moment.duration)',
                 default: '',
                 description: 'The initial value of the control.',
                 allowedTypes: ''

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -35,18 +35,18 @@ export default class DurationPickerSample extends React.Component {
 
                 <DurationPicker
                     id="duration-picker-2"
+                    onChange={this._onDurationPicker2Change}
                     showMinutes
                     showSeconds
-                    onChange={this._onDurationPicker2Change}
                     value={this.state.value2}
                 />
 
                 <DurationPicker
                     id="duration-picker-3"
+                    onChange={this._onDurationPicker3Change}
                     showHours={false}
                     showMonths
                     showYears
-                    onChange={this._onDurationPicker3Change}
                     value={this.state.value3}
                 />
             </div>
@@ -257,22 +257,25 @@ export default class ModulesDurationPicker extends React.Component {
                     value={this.state.value1}
                 />
 
-                <p>You can use the <code>showXXX</code> props to include or exclude various units of time.</p>
+              <p>
+                You can use the <code>showXXX</code> props to include or exclude various units of time.<br />
+                This one has days and hours (by default) and opts in to include minutes and seconds as well.
+              </p>
 
                 <DurationPicker
+                    onChange={this._onDurationPicker2Change}
                     showMinutes
                     showSeconds
-                    onChange={this._onDurationPicker2Change}
                     value={this.state.value2}
                 />
 
-                <br />
+                <p>This one shows years, months and days, opting out of hours</p>
 
                 <DurationPicker
+                    onChange={this._onDurationPicker3Change}
                     showHours={false}
                     showMonths
                     showYears
-                    onChange={this._onDurationPicker3Change}
                     value={this.state.value3}
                 />
 

--- a/docs/src/js/components/ModulesDurationPicker.react.js
+++ b/docs/src/js/components/ModulesDurationPicker.react.js
@@ -257,10 +257,10 @@ export default class ModulesDurationPicker extends React.Component {
                     value={this.state.value1}
                 />
 
-              <p>
-                You can use the <code>showXXX</code> props to include or exclude various units of time.<br />
-                This one has days and hours (by default) and opts in to include minutes and seconds as well.
-              </p>
+                <p>
+                    You can use the <code>showXXX</code> props to include or exclude various units of time.<br />
+                    This one has days and hours (by default) and opts in to include minutes and seconds as well.
+                </p>
 
                 <DurationPicker
                     onChange={this._onDurationPicker2Change}

--- a/docs/src/js/components/ModulesTimePicker.react.js
+++ b/docs/src/js/components/ModulesTimePicker.react.js
@@ -79,11 +79,13 @@ export default class NestSample extends React.Component {
 
     render() {
         return (
-            <TimePicker
-                nest
-                onChange={this._onNestChange.bind(this)}
-                value={this.state.nestValue}
-            />
+            <div className="some-class-that-has-nested-bkgd-color">
+                <TimePicker
+                    nest
+                    onChange={this._onNestChange.bind(this)}
+                    value={this.state.nestValue}
+                />
+            </div>
         );
     }
 
@@ -338,7 +340,7 @@ export default class ModulesTimePicker extends React.Component {
                 <Header size="large" style={{ marginTop: '55px' }} sub>
                     Range
                     <Header.Subheader>
-                        A Time Picker can give the appearance of being nested. The parent's background color needs to be set to <code>$bkgd-nest</code>.
+                        A Time Picker can be used in range mode, specifing a start time and an end time for the range.
                     </Header.Subheader>
                 </Header>
 

--- a/src/Elements/Input.react.js
+++ b/src/Elements/Input.react.js
@@ -229,47 +229,50 @@ class Input extends Component {
     }
 
     _onChange(event) {
-        const { max, min, onChange, required } = this.props;
-        const type = this._getType();
-        let newValue = event.target.value;
+        const { disabled, max, min, onChange, required } = this.props;
 
-        if (type === 'number') {
-            if (this.inputTimer) {
-                clearTimeout(this.inputTimer);
-            }
+        if (!disabled) {
+            const type = this._getType();
+            let newValue = event.target.value;
 
-            this.inputTimer = setTimeout(() => {
-                if (_.isEmpty(newValue)) {
-                    if (required) {
-                        newValue = _.isNumber(min) ? min : (_.isNumber(max)? max : 0);
-                    }
-                } else {
-                    newValue = +newValue;
-                    if (_.isNumber(max)) {
-                        newValue = Math.min(max, newValue);
-                    }
-                    if (_.isNumber(min)) {
-                        newValue = Math.max(min, newValue);
-                    }
+            if (type === 'number') {
+                if (this.inputTimer) {
+                    clearTimeout(this.inputTimer);
                 }
+
+                this.inputTimer = setTimeout(() => {
+                    if (_.isEmpty(newValue)) {
+                        if (required) {
+                            newValue = _.isNumber(min) ? min : (_.isNumber(max)? max : 0);
+                        }
+                    } else {
+                        newValue = +newValue;
+                        if (_.isNumber(max)) {
+                            newValue = Math.min(max, newValue);
+                        }
+                        if (_.isNumber(min)) {
+                            newValue = Math.max(min, newValue);
+                        }
+                    }
+
+                    if (_.isUndefined(onChange)) {
+                        this.setState({ value: newValue });
+                    } else {
+                        onChange(newValue);
+                    }
+                }, 500);
 
                 if (_.isUndefined(onChange)) {
                     this.setState({ value: newValue });
                 } else {
                     onChange(newValue);
                 }
-            }, 500);
-
-            if (_.isUndefined(onChange)) {
-                this.setState({ value: newValue });
             } else {
-                onChange(newValue);
-            }
-        } else {
-            if (_.isUndefined(onChange)) {
-                this.setState({ value: newValue });
-            } else {
-                onChange(newValue);
+                if (_.isUndefined(onChange)) {
+                    this.setState({ value: newValue });
+                } else {
+                    onChange(newValue);
+                }
             }
         }
     }

--- a/src/Elements/Input.react.js
+++ b/src/Elements/Input.react.js
@@ -148,7 +148,7 @@ class Input extends Component {
                         }}
                     >
                         {_.isString(icon) || loading ? (
-                            <Icon compact={true} spin={loading} type={loading ? 'spinner' : icon} />
+                            <Icon compact spin={loading} type={loading ? 'spinner' : icon} />
                         ) : _.isObject(icon) ? (
                             <div className="input-icon-custom" style={{ pointerEvents: 'auto' }}>
                                 {icon}
@@ -158,12 +158,14 @@ class Input extends Component {
                         {type === 'number' && showSpinners ? (
                             <div className="input-number-controls" style={{ pointerEvents: disabled ? 'none' : 'auto' }}>
                                 <Icon
+                                    compact
                                     onClick={this._onNumberToggleClick.bind(this, 'up')}
                                     size="xsmall"
                                     title={'Increase'}
                                     type="caret-up"
                                 />
                                 <Icon
+                                    compact
                                     onClick={this._onNumberToggleClick.bind(this, 'down')}
                                     size="xsmall"
                                     title={'Decrease'}

--- a/src/Elements/Input.react.js
+++ b/src/Elements/Input.react.js
@@ -28,9 +28,9 @@ class Input extends Component {
         this.inputTimer = null;
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (this.props.value !== nextProps.value) {
-            this.setState({ value: nextProps.value });
+    componentDidUpdate(prevProps, prevState) {
+        if (this.props.value !== prevProps.value) {
+            this.setState({ value: this.props.value });
         }
     }
 
@@ -156,9 +156,19 @@ class Input extends Component {
                         ) : null}
 
                         {type === 'number' && showSpinners ? (
-                            <div className="input-number-controls" style={{ pointerEvents: 'auto' }}>
-                                <Icon compact={true} onClick={this._onNumberToggleClick.bind(this, 'up')} size="xsmall" type="caret-up" />
-                                <Icon compact={true} onClick={this._onNumberToggleClick.bind(this, 'down')} size="xsmall" type="caret-down" />
+                            <div className="input-number-controls" style={{ pointerEvents: disabled ? 'none' : 'auto' }}>
+                                <Icon
+                                    onClick={this._onNumberToggleClick.bind(this, 'up')}
+                                    size="xsmall"
+                                    title={'Increase'}
+                                    type="caret-up"
+                                />
+                                <Icon
+                                    onClick={this._onNumberToggleClick.bind(this, 'down')}
+                                    size="xsmall"
+                                    title={'Decrease'}
+                                    type="caret-down"
+                                />
                             </div>
                         ) : null}
                     </div>
@@ -299,22 +309,25 @@ class Input extends Component {
 
     _onNumberToggleClick(action) {
         const { value } = this.state;
-        const { max, min, type, onChange } = this.props;
-        let newValue = value || 0;
+        const { disabled, max, min, type, onChange } = this.props;
 
-        switch(action) {
-            case 'down':
-                newValue = type === 'number' && _.isNumber(min) && value * 1 - 1 < min ? newValue : --newValue;
-                break;
-            case 'up':
-                newValue = type === 'number' && _.isNumber(max) && value * 1 + 1 > max ? newValue : ++newValue;
-                break;
-        }
+        if (!disabled) {
+            let newValue = value || 0;
 
-        if (_.isUndefined(onChange)) {
-            this.setState({ value: newValue });
-        } else {
-            onChange(newValue);
+            switch(action) {
+                case 'down':
+                    newValue = type === 'number' && _.isNumber(min) && value * 1 - 1 < min ? newValue : --newValue;
+                    break;
+                case 'up':
+                    newValue = type === 'number' && _.isNumber(max) && value * 1 + 1 > max ? newValue : ++newValue;
+                    break;
+            }
+
+            if (_.isUndefined(onChange)) {
+                this.setState({ value: newValue });
+            } else {
+                onChange(newValue);
+            }
         }
     }
 }

--- a/src/Modules/DurationPicker.react.js
+++ b/src/Modules/DurationPicker.react.js
@@ -76,11 +76,16 @@ class DurationPicker extends Component {
         });
 
         // TODO/FIXME: Is there a smarter way for this? :-)
-        const showHoursMinutesSeconds = showHours && showMinutes && showSeconds;
-        const showHoursAndMinutes = showHours && showMinutes && !showSeconds;
-        const showMinutesAndSeconds = showMinutes && showSeconds && !showHours;
-        const needsHoursToMinutesSeparator = showHoursMinutesSeconds || showHoursAndMinutes;
-        const needsMinutesToSecondsSeparator = showHoursMinutesSeconds || showMinutesAndSeconds;
+        const needsHoursToMinutesSeparator = showHours && showMinutes;
+        const needsMinutesToSecondsSeparator = showMinutes && showSeconds;
+        const onlyOne =
+            showHours && !showMinutes && !showSeconds ||
+            showMinutes && !showHours && !showSeconds ||
+            showSeconds && !showHours && !showMinutes;
+
+        const hhMmSsClasses = ClassNames('hh-mm-ss', {
+            'only-one': onlyOne
+        });
 
         return (
             <div
@@ -134,54 +139,56 @@ class DurationPicker extends Component {
                     />
                 ) : null}
 
-                {showHours ? (
-                    <Input
-                        className="duration-picker-input"
-                        disabled={disabled}
-                        id={`${id || 'duration-picker'}-hours`}
-                        label="Hours"
-                        max={23}
-                        min={0}
-                        ref="hoursPicker"
-                        type="number"
-                        value={hours}
-                        onChange={this._onHoursChange}
-                    />
-                ) : null}
+                <div className={hhMmSsClasses}>
+                  {showHours ? (
+                      <Input
+                          className="duration-picker-input"
+                          disabled={disabled}
+                          id={`${id || 'duration-picker'}-hours`}
+                          label="Hours"
+                          max={23}
+                          min={0}
+                          ref="hoursPicker"
+                          type="number"
+                          value={hours}
+                          onChange={this._onHoursChange}
+                      />
+                  ) : null}
 
-                {needsHoursToMinutesSeparator ? colonJsx : null}
+                  {needsHoursToMinutesSeparator ? colonJsx : null}
 
-                {showMinutes ? (
-                    <Input
-                        className="duration-picker-input"
-                        disabled={disabled}
-                        id={`${id || 'duration-picker'}-minutes`}
-                        label="Minutes"
-                        max={59}
-                        min={0}
-                        ref="minutesPicker"
-                        type="number"
-                        value={minutes}
-                        onChange={this._onMinutesChange}
-                    />
-                ) : null}
+                  {showMinutes ? (
+                      <Input
+                          className="duration-picker-input"
+                          disabled={disabled}
+                          id={`${id || 'duration-picker'}-minutes`}
+                          label="Minutes"
+                          max={59}
+                          min={0}
+                          ref="minutesPicker"
+                          type="number"
+                          value={minutes}
+                          onChange={this._onMinutesChange}
+                      />
+                  ) : null}
 
-                {needsMinutesToSecondsSeparator ? colonJsx : null}
+                  {needsMinutesToSecondsSeparator ? colonJsx : null}
 
-                {showMinutes ? (
-                    <Input
-                        className="duration-picker-input"
-                        disabled={disabled}
-                        id={`${id || 'duration-picker'}-seconds`}
-                        label="Seconds"
-                        max={59}
-                        min={0}
-                        ref="secondsPicker"
-                        type="number"
-                        value={seconds}
-                        onChange={this._onSecondsChange}
-                    />
-                ) : null}
+                  {showSeconds ? (
+                      <Input
+                          className="duration-picker-input"
+                          disabled={disabled}
+                          id={`${id || 'duration-picker'}-seconds`}
+                          label="Seconds"
+                          max={59}
+                          min={0}
+                          ref="secondsPicker"
+                          type="number"
+                          value={seconds}
+                          onChange={this._onSecondsChange}
+                      />
+                  ) : null}
+                </div>
             </div>
         )
     }

--- a/src/Modules/DurationPicker.react.js
+++ b/src/Modules/DurationPicker.react.js
@@ -1,0 +1,297 @@
+'use strict';
+
+import _ from 'lodash';
+import ClassNames from 'classnames';
+import Header from '../Elements/Header.react';
+import Input from '../Elements/Input.react';
+import moment from 'moment-timezone';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+const defaultState = {
+    years: 0,
+    months: 0,
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    value: null
+};
+
+const colonJsx = (
+    <span className="colon">:</span>
+);
+
+class DurationPicker extends Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = Object.assign({}, defaultState);
+
+        this._areMomentDurationsEqual = this._areMomentDurationsEqual.bind(this);
+        this._buildMomentDuration = this._buildMomentDuration.bind(this);
+        this._handleStateChange = this._handleStateChange.bind(this);
+        this._onDaysChange = this._onDaysChange.bind(this);
+        this._onHoursChange = this._onHoursChange.bind(this);
+        this._onMinutesChange = this._onMinutesChange.bind(this);
+        this._onMonthsChange = this._onMonthsChange.bind(this);
+        this._onSecondsChange = this._onSecondsChange.bind(this);
+        this._onYearsChange = this._onYearsChange.bind(this);
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        const { value: nextValue } = this.props;
+        const { value: prevValue } = prevState;
+
+        if (!this._areMomentDurationsEqual(prevValue, nextValue)) {
+            if (moment.isDuration(nextValue)) {
+                this.setState({
+                    days: nextValue.days(),
+                    hours: nextValue.hours(),
+                    minutes: nextValue.minutes(),
+                    months: nextValue.months(),
+                    seconds: nextValue.seconds(),
+                    years: nextValue.years(),
+                    value: nextValue
+                });
+            } else { // if value is nil or invalid, reset to default state
+                this.setState(defaultState);
+            }
+        }
+    }
+
+    render() {
+        const { className, disabled, error, id, nest, required,
+            showDays,showHours, showMinutes, showMonths, showSeconds, showYears,
+            style
+        } = this.props;
+
+        const { days, hours, minutes, months, seconds, value, years } = this.state;
+
+        const containerClasses = ClassNames('ui', 'duration-picker', className, {
+            'duration-picker-disable': disabled,
+            'duration-picker-error': error,
+            'duration-picker-nest': nest,
+        });
+
+        // TODO/FIXME: Is there a smarter way for this? :-)
+        const showHoursMinutesSeconds = showHours && showMinutes && showSeconds;
+        const showHoursAndMinutes = showHours && showMinutes && !showSeconds;
+        const showMinutesAndSeconds = showMinutes && showSeconds && !showHours;
+        const needsHoursToMinutesSeparator = showHoursMinutesSeconds || showHoursAndMinutes;
+        const needsMinutesToSecondsSeparator = showHoursMinutesSeconds || showMinutesAndSeconds;
+
+        return (
+            <div
+                className={containerClasses}
+                id={id}
+                ref="durationPicker"
+                style={style}
+            >
+                {showYears ? (
+                    <Input
+                        className="duration-picker-input"
+                        disabled={disabled}
+                        id={`${id || 'duration-picker'}-years`}
+                        label="Years"
+                        max={99}
+                        min={0}
+                        ref="yearsPicker"
+                        type="number"
+                        value={years}
+                        onChange={this._onYearsChange}
+                    />
+                ) : null}
+
+                {showMonths ? (
+                    <Input
+                        className="duration-picker-input"
+                        disabled={disabled}
+                        id={`${id || 'duration-picker'}-months`}
+                        label="Months"
+                        max={11}
+                        min={0}
+                        ref="monthsPicker"
+                        type="number"
+                        value={months}
+                        onChange={this._onMonthsChange}
+                    />
+                ) : null}
+
+                {showDays ? (
+                    <Input
+                        className="duration-picker-input"
+                        disabled={disabled}
+                        id={`${id || 'duration-picker'}-days`}
+                        label="Days"
+                        max={29}
+                        min={0}
+                        ref="daysPicker"
+                        type="number"
+                        value={days}
+                        onChange={this._onDaysChange}
+                    />
+                ) : null}
+
+                {showHours ? (
+                    <Input
+                        className="duration-picker-input"
+                        disabled={disabled}
+                        id={`${id || 'duration-picker'}-hours`}
+                        label="Hours"
+                        max={23}
+                        min={0}
+                        ref="hoursPicker"
+                        type="number"
+                        value={hours}
+                        onChange={this._onHoursChange}
+                    />
+                ) : null}
+
+                {needsHoursToMinutesSeparator ? colonJsx : null}
+
+                {showMinutes ? (
+                    <Input
+                        className="duration-picker-input"
+                        disabled={disabled}
+                        id={`${id || 'duration-picker'}-minutes`}
+                        label="Minutes"
+                        max={59}
+                        min={0}
+                        ref="minutesPicker"
+                        type="number"
+                        value={minutes}
+                        onChange={this._onMinutesChange}
+                    />
+                ) : null}
+
+                {needsMinutesToSecondsSeparator ? colonJsx : null}
+
+                {showMinutes ? (
+                    <Input
+                        className="duration-picker-input"
+                        disabled={disabled}
+                        id={`${id || 'duration-picker'}-seconds`}
+                        label="Seconds"
+                        max={59}
+                        min={0}
+                        ref="secondsPicker"
+                        type="number"
+                        value={seconds}
+                        onChange={this._onSecondsChange}
+                    />
+                ) : null}
+            </div>
+        )
+    }
+
+    _areMomentDurationsEqual(durationA, durationB) {
+        const durationAHasValue = moment.isDuration(durationA);
+        const durationBHasValue = moment.isDuration(durationB);
+
+        if (!durationAHasValue && !durationBHasValue) {
+            return true;
+        } else if (!durationAHasValue) {
+            return false;
+        } else if (!durationBHasValue) {
+            return false;
+        } else { // both are valid moment duration objects
+            return durationA.valueOf() === durationB.valueOf();
+        }
+    }
+
+    _buildMomentDuration(updatedState) {
+        const { days, hours, minutes, months, seconds, years } = updatedState;
+        return moment.duration({
+            seconds,
+            minutes,
+            hours,
+            days,
+            months,
+            years
+        });
+    }
+
+    _handleStateChange(updatedState) {
+        const updatedMomentDurationValue = this._buildMomentDuration(
+            Object.assign({}, this.state, updatedState)
+        );
+
+        const { onChange } = this.props;
+
+        if (_.isFunction(onChange)) { // controlled component; we own the unit of time component states, but _not_ the complete value state
+            this.setState(updatedState); // update the local state that we do own
+            onChange(updatedMomentDurationValue); // call `onChange()` with the updated value
+        } else { // uncontrolled component ... we own the complete value state
+            const finalUpdatedState = Object.assign(
+                {},
+                updatedState,
+                { value: updatedMomentDurationValue });
+
+            this.setState(finalUpdatedState);
+        }
+    }
+
+    _onDaysChange(value) {
+        this._handleStateChange({ days: value });
+    }
+
+    _onHoursChange(value) {
+        this._handleStateChange({ hours: value });
+    }
+
+    _onMinutesChange(value) {
+        this._handleStateChange({ minutes: value });
+    }
+
+    _onMonthsChange(value) {
+        this._handleStateChange({ months: value });
+    }
+
+    _onSecondsChange(value) {
+        this._handleStateChange({ seconds: value });
+    }
+
+    _onYearsChange(value) {
+        this._handleStateChange({ years: value });
+    }
+}
+
+DurationPicker.propTypes = {
+    className: PropTypes.string,
+    disabled: PropTypes.bool,
+    error: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string
+    ]),
+    id: PropTypes.string,
+    onChange: PropTypes.func,
+    required: PropTypes.bool,
+    showDays: PropTypes.bool,
+    showHours: PropTypes.bool,
+    showMinutes: PropTypes.bool,
+    showMonths: PropTypes.bool,
+    showSeconds: PropTypes.bool,
+    showYears: PropTypes.bool,
+    value: (props, propName, componentName) => {
+        const theProp = props[propName];
+        if (!_.isNil(theProp) && !moment.isDuration(theProp)) {
+            return new Error(
+                'Invalid prop `' + propName + '` supplied to' +
+                ' `' + componentName + '`. Validation failed.'
+            );
+        }
+    } // TODO: There is a `react-moment-proptypes` package we can consider [ https://www.npmjs.com/package/react-moment-proptypes ]
+};
+
+DurationPicker.defaultProps = {
+    showDays: true,
+    showHours: true,
+    showMinutes: false,
+    showMonths: false,
+    showSeconds: false,
+    showYears: false
+}
+
+export default DurationPicker;

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export { default as Chart } from './Modules/Chart.react.js';
 export { default as DatePicker } from './Modules/DatePicker.react.js';
 export { default as Drawer } from './Modules/Drawer.react.js';
 export { default as Dropdown } from './Modules/Dropdown.react.js';
+export { default as DurationPicker } from './Modules/DurationPicker.react.js';
 export { default as Modal } from './Modules/Modal.react.js';
 export { default as PhoneInput } from './Modules/PhoneInput.react.js';
 export { default as Prompt } from './Modules/Prompt.react.js';

--- a/src/scss/Style.scss
+++ b/src/scss/Style.scss
@@ -47,6 +47,7 @@
 @import 'components/Modules/DatePickerWeek';
 @import 'components/Modules/Drawer';
 @import 'components/Modules/Dropdown';
+@import 'components/Modules/DurationPicker';
 @import 'components/Modules/Modal';
 @import 'components/Modules/PhoneInput';
 @import 'components/Modules/Prompt';

--- a/src/scss/components/Modules/DurationPicker.scss
+++ b/src/scss/components/Modules/DurationPicker.scss
@@ -1,0 +1,20 @@
+@import '../../config/Colors', '../../config/Fonts', '../../config/FontSizeCalculator';
+
+.ui.duration-picker {
+    align-items: flex-start;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    position: relative;
+    .colon { font-size: rem(24px); margin: 28px rem(11px) 0 rem(2.5px); }
+    .duration-picker-input { width: 100%; }
+}
+
+@media only screen and (min-width: 480px) {
+    .ui.duration-picker {
+        display: inline-flex;
+        flex-direction: row;
+        .duration-picker-input { margin: 0 11px 11px 0; width: 121px; }
+    }
+}

--- a/src/scss/components/Modules/DurationPicker.scss
+++ b/src/scss/components/Modules/DurationPicker.scss
@@ -7,8 +7,13 @@
     flex-wrap: wrap;
     justify-content: flex-start;
     position: relative;
-    .colon { font-size: rem(24px); margin: 28px rem(11px) 0 rem(2.5px); }
+    .colon { display: none; }
     .duration-picker-input { width: 100%; }
+    .hh-mm-ss {
+        width: 100%;
+        .duration-picker-input:first-child { margin-top: -11px; }
+        .duration-picker-input { margin-top: 22px }
+    }
 }
 
 @media only screen and (min-width: 480px) {
@@ -16,5 +21,12 @@
         display: inline-flex;
         flex-direction: row;
         .duration-picker-input { margin: 0 11px 11px 0; width: 121px; }
+        .colon { display: inline-flex; font-size: rem(24px); margin: 28px rem(11px) 0 rem(2.5px); }
+        .hh-mm-ss {
+            margin-top: -22px;
+            width: auto;
+            &.only-one { margin-top: 0 }
+            .duration-picker-input:first-child { margin-top: 0 }
+        }
     }
 }


### PR DESCRIPTION
**Overview**
Adds a **`DurationPicker`** component to the React CM UI library.  This component allows you to specify a length of time by various units (days, hours, minutes, etc.).  As an example, this component will be used to say that Follow Up Tasks (for the "Workflows" feature) are due after X number of days or Y number of hours.

**Background**
As a part of cleaning up some technical debt in the Workflows area (mostly in API/back-end but also some in front-end) I'm going to try and decompose the "Workflow Rule Editor" component into some smaller sub-components (the component in question currently lives alongside other components for the editing of Connection Card [Response Card] Templates).  Currently, something very much like the `DurationPicker` component here exists inside a much larger and complicated component; it seemed like a good first candidate to extract out.

![image](https://user-images.githubusercontent.com/4349658/51417502-2f28dd00-1b33-11e9-863a-507db66d7704.png)
