### PR TITLE
[dev] [NoPBI] Fixes the issues when Drawer child's onClose was overridden

### DIFF
--- a/src/Modules/Drawer.react.js
+++ b/src/Modules/Drawer.react.js
@@ -419,7 +419,7 @@ class Drawer extends Component {
             document.removeEventListener('click', this._onClickOutside);
         }
 
-        onClose();
+        onClose(...arguments);
     }
 
     _onCloseAnimationComplete() {


### PR DESCRIPTION
@morethanfire 
We've found that there was a change made recently that brakes some drawers. 
The change is about overriding onClose property of child in react-cm-ui library, so a child misses the passed arguments.
Here is a small fix that fixes drawers like in Worship services `src/js/components/Admin/WorshipServiceSetup/WorshipServiceDrawer.react.js`
As of now we found 4 such drawers and there are more 