### PR TITLE
[dev] Avatar (User Icon) Image Fixes/Enhancements for PBI AB#16313

### DIFF
--- a/docs/src/js/components/ElementsImage.react.js
+++ b/docs/src/js/components/ElementsImage.react.js
@@ -2,15 +2,11 @@
 
 import 'images/marty-mcfly.jpg';
 
-import PropTypes from 'prop-types';
-import React from 'react';
 import { Card, Header, Image, TitleBar } from 'react-cm-ui';
-
-// Docs UI Components
-import Block from 'components/UI/Block.react';
-import Highlighter from 'components/UI/Highlighter.react';
-import Main from 'components/UI/Main.react';
-import TableProps from 'components/UI/TableProps.react';
+import Highlighter from 'components/UI/Highlighter.react.js';
+import Main from 'components/UI/Main.react.js';
+import React from 'react';
+import TableProps from 'components/UI/TableProps.react.js';
 
 const imageSample = `import React from 'react';
 import { Image } from 'react-cm-ui';
@@ -56,7 +52,11 @@ export default class SizeSample extends React.Component {
             <div>
                 <Image src="/images/marty-mcfly.jpg" size={100} /><br /><br />
                 <Image avatar size={44} name="Marty McFly" /><br /><br />
-                <Image avatar size={66} src="/images/marty-mcfly.jpg" />
+                <Image avatar size={66} src="/images/marty-mcfly.jpg" /><br /><br />
+                <Image avatar size={22} /><br /><br />
+                <Image avatar size={44} /><br /><br />
+                <Image avatar size={66} /><br /><br />
+                <Image avatar size={88} />
             </div>
         );
     }
@@ -70,13 +70,13 @@ export default class ElementsImage extends React.Component {
                 type: 'enum',
                 default: 'img',
                 description: 'An element type to render as.',
-                allowedTypes: 'div, img'
+                allowedTypes: 'div, img',
             }, {
                 name: 'avatar',
                 type: 'bool',
                 default: '',
                 description: 'An Image can be shown as a circular avatar.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'className',
                 type: 'string',
@@ -88,20 +88,20 @@ export default class ElementsImage extends React.Component {
                 type: 'number',
                 default: '',
                 description: 'Size of Image.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'src',
                 type: 'string',
                 default: '',
                 description: 'Path to image file.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'style',
                 type: 'object',
                 default: '',
                 description: 'Supply any inline styles to the Image or Image\'s container.',
-                allowedTypes: ''
-            }
+                allowedTypes: '',
+            },
         ];
 
         const martyMcFlyImageSrc = window.location.host.indexOf('localhost') > -1 ?
@@ -119,7 +119,7 @@ export default class ElementsImage extends React.Component {
                 </Card>
 
                 {/* Image */}
-                <Header size="large" style={{ marginTop: '55px' }} sub={true}>
+                <Header size="large" style={{ marginTop: '55px' }} sub>
                     Image
                     <Header.Subheader>
                         An image.
@@ -133,7 +133,7 @@ export default class ElementsImage extends React.Component {
                 </Highlighter>
 
                 {/* Avatar */}
-                <Header size="large" style={{ marginTop: '55px' }} sub={true}>
+                <Header size="large" style={{ marginTop: '55px' }} sub>
                     Avatar
                     <Header.Subheader>
                         An image can be an avatar.
@@ -151,7 +151,7 @@ export default class ElementsImage extends React.Component {
                 </Highlighter>
 
                 {/* Size */}
-                <Header size="large" style={{ marginTop: '55px' }} sub={true}>
+                <Header size="large" style={{ marginTop: '55px' }} sub>
                     Size
                     <Header.Subheader>
                         Passing a size (number) will contrain the image by its width.
@@ -160,7 +160,11 @@ export default class ElementsImage extends React.Component {
 
                 <Image src={martyMcFlyImageSrc} size={100} /><br /><br />
                 <Image avatar size={44} name="Marty McFly" /><br /><br />
-                <Image avatar size={66} src={martyMcFlyImageSrc} />
+                <Image avatar size={66} src={martyMcFlyImageSrc} /><br /><br />
+                <Image avatar size={22} /><br /><br />
+                <Image avatar size={44} /><br /><br />
+                <Image avatar size={66} /><br /><br />
+                <Image avatar size={88} />
 
                 <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
                     {sizeSample}
@@ -168,5 +172,4 @@ export default class ElementsImage extends React.Component {
             </Main>
         );
     }
-
 }

--- a/docs/src/js/components/ModulesAccordion.react.js
+++ b/docs/src/js/components/ModulesAccordion.react.js
@@ -1,16 +1,13 @@
 
 'use strict';
 
-import PropTypes from 'prop-types';
+import { Accordion, Card, Header, SubNavigation, TitleBar } from 'react-cm-ui';
+import Block from 'components/UI/Block.react.js';
+import Highlighter from 'components/UI/Highlighter.react.js';
+import Main from 'components/UI/Main.react.js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ScrollBar from 'react-custom-scrollbars';
-import { Accordion, Card, Header, SubNavigation, TitleBar } from 'react-cm-ui';
-
-// Docs UI Components
-import Block from 'components/UI/Block.react';
-import Highlighter from 'components/UI/Highlighter.react';
-import Main from 'components/UI/Main.react';
 import TableProps from 'components/UI/TableProps.react';
 
 const accordionSample = `import React from 'react';
@@ -392,8 +389,7 @@ export default class CustomSummarySample extends React.Component {
             </div>
         );
     }
-}`
-
+}`;
 
 export default class CollectionsAccordion extends React.Component {
     constructor(props) {
@@ -402,10 +398,11 @@ export default class CollectionsAccordion extends React.Component {
         this.state = {
             scrollBarNode: null,
             subNavIndex: 0,
-            controlledExampleSelectedIndex: 0 // first item expanded by default
+            controlledExampleSelectedIndex: 0, // first item expanded by default
         };
 
         this._onClickAccordionItem = this._onClickAccordionItem.bind(this);
+        this._onClickBasicAccordionItem = this._onClickBasicAccordionItem.bind(this);
     }
 
     render() {
@@ -416,38 +413,38 @@ export default class CollectionsAccordion extends React.Component {
                 type: 'bool',
                 default: '',
                 description: 'Simplify an Accordion to a basic pared down style.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'className',
                 type: 'string',
                 default: '',
                 description: 'Additional classes.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'exclusive',
                 type: 'bool',
                 default: 'true',
                 description: 'Only allow one Accordion Item to open at a time.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'inverse',
                 type: 'bool',
                 default: '',
                 description: 'Format to appear on dark backgrounds.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'selected',
                 type: 'array || number',
                 default: '',
                 description: 'Change the default selected Accordion Item.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'style',
                 type: 'object',
                 default: '',
                 description: 'Supply any inline styles to the Accordion\'s container. Mainly used for padding and margins.',
-                allowedTypes: ''
-            }
+                allowedTypes: '',
+            },
         ];
 
         const itemProps = [
@@ -456,26 +453,26 @@ export default class CollectionsAccordion extends React.Component {
                 type: 'string',
                 default: '',
                 description: 'Additional classes.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'style',
                 type: 'object',
                 default: '',
                 description: 'Supply any inline styles to the Accordion\'s Item container. Mainly used for padding and margins.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'subAccordion',
                 type: 'bool',
                 default: '',
                 description: 'Required boolean for Accordion\'s nested inside of Accordion Item container.',
-                allowedTypes: ''
+                allowedTypes: '',
             }, {
                 name: 'summary',
                 type: 'bool',
                 default: 'true',
                 description: 'Use custom content within an Accordion\'s Item.',
-                allowedTypes: ''
-            }
+                allowedTypes: '',
+            },
         ];
 
         let examplesJSX;
@@ -603,7 +600,7 @@ export default class CollectionsAccordion extends React.Component {
                     <Header size="large" style={{ marginTop: '55px' }} sub>
                         Accordion
                         <Header.Subheader>
-                            A baisc Accordion can be inverted to appear on darker backgrounds better.
+                            A basic Accordion can be inverted to appear on darker backgrounds better.
                         </Header.Subheader>
                     </Header>
 
@@ -642,11 +639,17 @@ export default class CollectionsAccordion extends React.Component {
                     </Header>
 
                     <Accordion basic>
-                        <Accordion.Item title="Option One">
+                        <Accordion.Item
+                            onClick={() => this._onClickBasicAccordionItem('Option One')}
+                            title="Option One"
+                        >
                             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo pretium odio, quis tristique sem suscipit eget. Morbi sit amet nibh quis lorem sodales suscipit. Nam a convallis sem. Pellentesque convallis tellus ex, nec finibus lacus placerat eget. Sed nec placerat nisl. Nam facilisis dolor non ante sollicitudin sollicitudin. Aliquam magna sem, ullamcorper eget ipsum tincidunt, lobortis semper magna. Mauris cursus urna nec tellus convallis mollis ut eget sem.</p>
                         </Accordion.Item>
 
-                        <Accordion.Item title="Option Two">
+                        <Accordion.Item
+                            onClick={() => this._onClickBasicAccordionItem('Option Two')}
+                            title="Option Two"
+                        >
                             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo pretium odio, quis tristique sem suscipit eget. Morbi sit amet nibh quis lorem sodales suscipit. Nam a convallis sem. Pellentesque convallis tellus ex, nec finibus lacus placerat eget. Sed nec placerat nisl. Nam facilisis dolor non ante sollicitudin sollicitudin. Aliquam magna sem, ullamcorper eget ipsum tincidunt, lobortis semper magna. Mauris cursus urna nec tellus convallis mollis ut eget sem.</p>
                         </Accordion.Item>
                     </Accordion><br /><br />
@@ -752,7 +755,12 @@ export default class CollectionsAccordion extends React.Component {
                     </Block><br /><br />
 
                     <Block inverse style={{ height: '205px' }}>
-                        <ScrollBar autoHide ref={scrollBarNode => { this.scrollBarNode = scrollBarNode }}>
+                        <ScrollBar
+                            autoHide
+                            ref={scrollBarNode => {
+                                this.scrollBarNode = scrollBarNode;
+                            }}
+                        >
                             <Accordion basic inverse scrollContainer={scrollBarNode} scrollContainerMarginHeight={15}>
                                 <Accordion.Item title="Option One">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo pretium odio, quis tristique sem suscipit eget. Morbi sit amet nibh quis lorem sodales suscipit. Nam a convallis sem. Pellentesque convallis tellus ex, nec finibus lacus placerat eget. Sed nec placerat nisl. Nam facilisis dolor non ante sollicitudin sollicitudin. Aliquam magna sem, ullamcorper eget ipsum tincidunt, lobortis semper magna. Mauris cursus urna nec tellus convallis mollis ut eget sem.</p>
@@ -814,7 +822,7 @@ export default class CollectionsAccordion extends React.Component {
                             <div
                                 dangerouslySetInnerHTML={{
                                     __html: `You can use the Accordion as a controlled component via the <strong>selected</strong> prop
-                                    by passing an <strong>onClick</strong> handler function to each item&rsquo;s summary.`
+                                    by passing an <strong>onClick</strong> handler function to each item&rsquo;s summary.`,
                                 }}
                             />
                         </Header.Subheader>
@@ -881,6 +889,10 @@ export default class CollectionsAccordion extends React.Component {
 
     _onClickAccordionItem(newSelectedIndex) {
         this.setState({ controlledExampleSelectedIndex: newSelectedIndex });
+    }
+
+    _onClickBasicAccordionItem(foo) {
+        console.log(`${foo} item was clicked!`); // eslint-disable-line no-console
     }
 
     _onSubNavClick(index) {

--- a/src/Elements/Icon.react.js
+++ b/src/Elements/Icon.react.js
@@ -34,8 +34,9 @@ class Icon extends React.Component {
             'icon-size-small': size === 'small',
             'icon-size-xlarge': size === 'xlarge',
             'icon-size-xsmall': size === 'xsmall',
+            'icon-size-xxlarge': size === 'xxlarge',
             'icon-size-xxsmall': size === 'xxsmall',
-            'icon-spin': spin || type === 'spinner'
+            'icon-spin': spin || type === 'spinner',
         });
         const containerStyle = _.merge(style, {
             height: _.isNumber(size) ? `${size / 16}rem` : null,
@@ -675,7 +676,7 @@ class Icon extends React.Component {
                     <svg style={svgStyle} viewBox="0 0 24 24">
                         <title>{title || type}</title>
                         <defs>
-                            <polygon id={pathId} transform="translate(12.000000, 12.000000) rotate(180.000000) translate(-12.000000, -12.000000) " points="12 5 24 19 0 19"></polygon>
+                            <polygon id={pathId} transform="translate(12.000000, 12.000000) rotate(180.000000) translate(-12.000000, -12.000000) " points="12 5 24 19 0 19" />
                             {renderGradientColor}
                         </defs>
                         <g fill="none" fillRule="evenodd">
@@ -698,7 +699,7 @@ class Icon extends React.Component {
                     <svg style={svgStyle} viewBox="0 0 24 24">
                         <title>{title || type}</title>
                         <defs>
-                            <polygon id={pathId} points="5 12 19 0 19 24"></polygon>
+                            <polygon id={pathId} points="5 12 19 0 19 24" />
                             {renderGradientColor}
                         </defs>
                         <g fill="none" fillRule="evenodd">
@@ -721,7 +722,7 @@ class Icon extends React.Component {
                     <svg style={svgStyle} viewBox="0 0 24 24">
                         <title>{title || type}</title>
                         <defs>
-                            <polygon id={pathId} transform="translate(14.000000, 12.000000) rotate(90.000000) translate(-14.000000, -12.000000) " points="14 5 26 19 2 19"></polygon>
+                            <polygon id={pathId} transform="translate(14.000000, 12.000000) rotate(90.000000) translate(-14.000000, -12.000000)" points="14 5 26 19 2 19" />
                             {renderGradientColor}
                         </defs>
                         <g fill="none" fillRule="evenodd">
@@ -767,7 +768,7 @@ class Icon extends React.Component {
                     <svg style={svgStyle} viewBox="0 0 24 24">
                         <title>{title || type}</title>
                         <defs>
-                            <polygon id={pathId} points="12 5 24 19 0 19"></polygon>
+                            <polygon id={pathId} points="12 5 24 19 0 19" />
                             {renderGradientColor}
                         </defs>
                         <g fill="none" fillRule="evenodd">
@@ -1028,7 +1029,7 @@ class Icon extends React.Component {
                     <svg style={svgStyle} viewBox="0 0 24 24">
                         <title>{title || type}</title>
                         <defs>
-                            <circle id={pathId} cx="12" cy="12" r="12"></circle>
+                            <circle id={pathId} cx="12" cy="12" r="12" />
                             {renderGradientColor}
                         </defs>
                         <g fill="none" fillRule="evenodd">
@@ -3645,12 +3646,12 @@ Icon.propTypes = {
     rotate: PropTypes.number,
     size: PropTypes.oneOfType([
         PropTypes.oneOf(Utils.sizeEnums()),
-        PropTypes.number
+        PropTypes.number,
     ]),
     spin: PropTypes.bool,
     style: PropTypes.object,
     title: PropTypes.string,
-    type: PropTypes.string.isRequired
+    type: PropTypes.string.isRequired,
 };
 
 export default Icon;

--- a/src/Elements/Image.react.js
+++ b/src/Elements/Image.react.js
@@ -1,12 +1,9 @@
 'use strict';
 
-import _ from 'lodash';
-import ClassNames from 'classnames';
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-import Icon from '../Elements/Icon.react';
-
+import ClassNames from 'classnames';
+import Icon from '../Elements/Icon.react.js';
+import PropTypes from 'prop-types';
 import Utils from '../utils/Utils.js';
 
 class Image extends Component {
@@ -21,13 +18,13 @@ class Image extends Component {
 
         const ElementType = Utils.getElementType(newAs, this.props);
         const containerClasses = ClassNames('ui', 'image', className, {
-            'image-avatar': avatar
+            'image-avatar': avatar,
         });
 
         if (ElementType === 'img') {
             newStyle = Object.assign({}, style, {
                 backgroundImage: src ? `url(${src})` : null,
-                width: size
+                width: size,
             });
 
             return (
@@ -39,21 +36,29 @@ class Image extends Component {
             );
         }
 
+        let newInitials, avatarSize = 'xsmall';
+
         if (avatar) {
             newStyle = Object.assign({}, style, {
                 boxShadow: src ? 'none' : null,
                 backgroundImage: src ? `url(${src})` : null,
                 fontSize: !size || size < 44 ? '.75rem' : '1.125rem',
                 height: size,
-                width: size
+                width: size,
             });
-        }
 
-        let newInitials;
+            if (name) {
+                newInitials = name.match(/\b\w/g) || [];
+                newInitials = ((newInitials.shift() || '') + (newInitials.pop() || '')).toUpperCase();
+            }
 
-        if (name) {
-            newInitials = name.match(/\b\w/g) || [];
-            newInitials = ((newInitials.shift() || '') + (newInitials.pop() || '')).toUpperCase();
+            if (size >= 88) {
+                avatarSize = 'xxlarge';
+            } else if (size >= 66) {
+                avatarSize = 'large';
+            } else if (size >= 44) {
+                avatarSize = 'small';
+            }
         }
 
         return (
@@ -65,7 +70,7 @@ class Image extends Component {
                 {avatar && !src ?
                     name ?
                         newInitials :
-                        ( <Icon color="static" compact size="xsmall" type="user" /> ) :
+                        ( <Icon color="static" compact size={avatarSize} title="This person has no image" type="user" /> ) :
                     null}
             </ElementType>
         );
@@ -81,7 +86,7 @@ Image.propTypes = {
     name: PropTypes.string,
     size: PropTypes.number,
     src: PropTypes.string,
-    style: PropTypes.object
+    style: PropTypes.object,
 };
 
 export default Image;

--- a/src/Modules/Accordion.react.js
+++ b/src/Modules/Accordion.react.js
@@ -1,14 +1,12 @@
 'use strict';
 
+import React, { Component } from 'react';
 import _ from 'lodash';
 import ClassNames from 'classnames';
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
-
-import Icon from '../Elements/Icon.react';
-
 import DOMUtils from '../utils/DOMUtils.js';
+import Icon from '../Elements/Icon.react.js';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
 
 class AccordionItem extends Component {
     constructor(props) {
@@ -32,7 +30,7 @@ class AccordionItem extends Component {
         const containerClasses = ClassNames('accordion-item', className, {
             'accordion-item-is-active': isSelected,
             'accordion-item-sub-accordion': subAccordion,
-            'accordion-item-no-summary': summary === false
+            'accordion-item-no-summary': summary === false,
         });
 
         return (
@@ -48,8 +46,8 @@ class AccordionItem extends Component {
             'animation': 'animationend',
             'OAnimation': 'oAnimationEnd',
             'MozAnimation': 'animationend',
-            'WebkitAnimation': 'webkitAnimationEnd'
-        }
+            'WebkitAnimation': 'webkitAnimationEnd',
+        };
 
         for (a in animations) {
             if (el.style[a] !== undefined) {
@@ -96,12 +94,12 @@ AccordionItem.propTypes = {
     isSelected: PropTypes.bool,
     scrollContainer: PropTypes.oneOfType([
         PropTypes.object,
-        PropTypes.string
+        PropTypes.string,
     ]),
     scrollContainerMarginHeight: PropTypes.number,
     style: PropTypes.object,
     subAccordion: PropTypes.bool,
-    summary: PropTypes.bool
+    summary: PropTypes.bool,
 };
 
 class AccordionSummary extends Component {
@@ -125,18 +123,17 @@ class AccordionSummary extends Component {
 }
 
 AccordionSummary.propTypes = {
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
 };
 
 class AccordionCheckbox extends Component {
-
     render() {
         return (
             <div
                 className="accordion-checkbox"
                 style={{
                     flex: '0 1 auto',
-                    minWidth: '44px'
+                    minWidth: '44px',
                 }}
             >
                 {this.props.children}
@@ -147,11 +144,10 @@ class AccordionCheckbox extends Component {
 
 AccordionCheckbox.propTypes = {
     className: PropTypes.string,
-    style: PropTypes.object
+    style: PropTypes.object,
 };
 
 class AccordionContent extends Component {
-
     render() {
         return (
             <div className="accordion-item-content" style={this.props.style}>
@@ -162,11 +158,10 @@ class AccordionContent extends Component {
 }
 
 AccordionContent.propTypes = {
-    style: PropTypes.object
+    style: PropTypes.object,
 };
 
 class Accordion extends Component {
-
     constructor(props) {
         super(props);
 
@@ -215,11 +210,11 @@ class Accordion extends Component {
         const containerClasses = ClassNames('ui', 'accordion', className, {
             'accordion-basic': basic,
             'accordion-inverse': inverse,
-            'accordion-inclusive': exclusive === false
+            'accordion-inclusive': exclusive === false,
         });
-        const convertChildren = _.isArray(children) ? children : [ children ];
-        let items = _.map(convertChildren, (child, index) => {
-            const { children, className, style, subTitle, subAccordion, summary, title } = child.props;
+        const convertedChildren = _.isArray(children) ? children : [ children ];
+        let items = _.map(convertedChildren, (child, index) => {
+            const { children, onClick, style, subTitle, subAccordion, summary, title } = child.props;
             const isSelected = exclusive === false ? _.includes(selected, index) : selected === index;
 
             if (title) {
@@ -235,10 +230,16 @@ class Accordion extends Component {
                     >
                         <div
                             className="accordion-item-title"
-                            onClick={this._onSummaryClick.bind(this, index)}
+                            onClick={this._onSummaryClick.bind(this, index, onClick)}
                         >
                             <span className="copy">{title}{subTitle ? <span className="padding-left">{subTitle}</span> : null}</span>
-                            <Icon compact={true} inverse={inverse} rotate={isSelected ? 135 : 0} type="plus" />
+                            <Icon
+                                compact
+                                inverse={inverse}
+                                rotate={isSelected ? 135 : 0}
+                                title={isSelected ? 'Collapse' : 'Expand'}
+                                type="plus"
+                            />
                         </div>
 
                         <AccordionContent>
@@ -319,7 +320,6 @@ class Accordion extends Component {
 
         this.setState({ selected: newSelected });
     }
-
 }
 
 Accordion.Content = AccordionContent;
@@ -335,14 +335,14 @@ Accordion.propTypes = {
     inverse: PropTypes.bool,
     scrollContainer: PropTypes.oneOfType([
         PropTypes.object,
-        PropTypes.string
+        PropTypes.string,
     ]),
     scrollContainerMarginHeight: PropTypes.number,
     selected: PropTypes.oneOfType([
         PropTypes.array,
-        PropTypes.number
+        PropTypes.number,
     ]),
-    style: PropTypes.object
+    style: PropTypes.object,
 };
 
 export default Accordion;

--- a/src/scss/components/Elements/Icon.scss
+++ b/src/scss/components/Elements/Icon.scss
@@ -36,6 +36,7 @@
     &-compact { margin: 0; }
     &.icon-disable { color: $color-text-disable; cursor: default; }
     &-size- {
+        &xxlarge, &xxlarge svg { height: rem(32px); width: rem(32px); }
         &xlarge, &xlarge svg { height: rem(24px); width: rem(24px); }
         &large, &large svg { height: rem(20px); width: rem(20px); }
         &medium, &medium svg { height: rem(18px); width: rem(18px); }

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -24,7 +24,7 @@ class Utils {
             'subject',
             'success',
             'transparent',
-            'warning'
+            'warning',
         ];
     }
 
@@ -37,7 +37,7 @@ class Utils {
     }
 
     static getIncreasingUniqueKey() {
-        var now = (new Date().getTime()).toString();
+        const now = (new Date().getTime()).toString();
         return now.substring(now.length - 6, now.length) + _.uniqueId();
     }
 
@@ -54,7 +54,7 @@ class Utils {
             9: 'nine',
             10: 'ten',
             11: 'eleven',
-            12: 'twelve'
+            12: 'twelve',
         };
 
         return numberToWordMap[num];
@@ -63,19 +63,20 @@ class Utils {
     static sizeEnums() {
         // Sorry, breaking the alphabetical order here in favor of Large to Small. Deal with it!
         return [
+            'xxlarge',
             'xlarge',
             'large',
             'medium',
             'small',
             'xsmall',
-            'xxsmall'
+            'xxsmall',
         ];
     }
 
     static themeEnums() {
         return [
             'dark',
-            'light'
+            'light',
         ];
     }
 }


### PR DESCRIPTION
* Add an `xxlarge` size option for `<Icon>` component
* Add logic to scale up Avatar Placeholder (User Icon) image depending on the size parameter passed to the `<Image>` component
* Add additional avatar image samples with various sizes to the Image documentation page
* Resolve ESLINT warnings in `Icon.react.js`, `Image.react.js` and `ElementsImage.react.js` documentation page

The reason for this is I need the Avatar to potentially look like this: 

https://sketch.cloud/s/vxGKM/bgDbkwo

![image](https://user-images.githubusercontent.com/4349658/57777842-a2a0bc80-76d7-11e9-801b-5fa850d359aa.png)

@morethanfire Please review the styles and sizing logic for images and icons thoroughly.  By logic I mean the "translation" from numeric sizes passed to `<Image>` component to a fixed size option (`small`, `medium`, `large`, etc.) for `<Icon>`.  I took a rough guess at it, and was able to get it doing this:

![image](https://user-images.githubusercontent.com/4349658/57777920-d5e34b80-76d7-11e9-9671-78835931ff25.png)
