### PR TITLE
[dev] [NoPBI] Fix React errors on passing an object as a title for Drawer

### DIFF
--- a/docs/src/js/components/ModulesDrawer.react.js
+++ b/docs/src/js/components/ModulesDrawer.react.js
@@ -1075,7 +1075,7 @@ export default class ModulesDrawer extends React.Component {
                 allowedTypes: '',
             }, {
                 name: 'title',
-                type: 'string',
+                type: 'string || object',
                 default: '',
                 description: 'Required string to give a Drawer a title.',
                 allowedTypes: '',

--- a/src/Modules/Drawer.react.js
+++ b/src/Modules/Drawer.react.js
@@ -122,8 +122,12 @@ class DrawerHeader extends Component {
 
         return (
             <header className="drawer-header" ref={ref => this._drawerHeaderRef = ref}>
-                {title ? (
-                    <Header as="h2" className={titleClass} title={title}>{title}</Header>
+                {_.isObject(title) ? (
+                    title
+                ) : title ? (
+                    <Header as="h2" className={titleClass} title={title}>
+                        {title}
+                    </Header>
                 ) : null}
 
                 <CloseButton closeButton={closeButton} inverse={inverse} onClose={onClose} />


### PR DESCRIPTION
Fixes warnings on passing object as title for drawers (too annoying / verbose during debugging) 