### PR TITLE
Fixes generating the key for the Page.Table header cell

### DIFF
--- a/src/modules/pageTable.js
+++ b/src/modules/pageTable.js
@@ -93,7 +93,7 @@ class PageTable extends React.PureComponent {
                                 return (
                                     <Table.HeaderCell
                                         className="page--table_header_cell"
-                                        key={`tableBodyRow-${column.header ? _.kebabCase(column.header) : index}`}
+                                        key={`tableBodyRow-${index}`}
                                     >
                                         {column.header}
                                     </Table.HeaderCell>


### PR DESCRIPTION
The `column.header` could be not only text (e.g. it maybe the `Checkbox` or `div`), so, the header cell key should be generated by index.