### PR TITLE
[dev] Page action bar mobile action buttons - Add ability to Prompt

### DIFF
--- a/docs/src/app/app.scss
+++ b/docs/src/app/app.scss
@@ -6,6 +6,7 @@ html, body, #coreApp, .core-app-root, .layout { height: 100%; }
     *, *::after, *::before { box-sizing: border-box; }
     body {
         background-color: color(backgroundColorLight);
+        overflow-y: scroll;
         .layout { position: relative; right: 0; transition: right 166ms linear; }
         &.pushed-right {
             overflow-x: hidden;

--- a/docs/src/modules/drawerSubNavigation.js
+++ b/docs/src/modules/drawerSubNavigation.js
@@ -126,58 +126,6 @@ class ModulesDrawerSubNavigation extends React.PureComponent {
             </SubNavigation>
         );
     }
-
-    _onSubNavClick(index) {
-        const drawerLocation = '/modules/drawer';
-
-        switch (index) {
-            case 0:
-                browserHistory.push(`${drawerLocation}/`);
-
-                break;
-
-            case 1:
-                browserHistory.push(`${drawerLocation}/action-bar`);
-
-                break;
-            case 2:
-                browserHistory.push(`${drawerLocation}/content`);
-
-                break;
-            case 3:
-                browserHistory.push(`${drawerLocation}/filters-drawer`);
-
-                break;
-            case 4:
-                browserHistory.push(`${drawerLocation}/grid`);
-
-                break;
-            case 5:
-                browserHistory.push(`${drawerLocation}/navigation`);
-
-                break;
-            case 6:
-                browserHistory.push(`${drawerLocation}/table`);
-
-                break;
-            case 7:
-                browserHistory.push(`${drawerLocation}/title-bar`);
-
-                break;
-            case 8:
-                browserHistory.push(`${drawerLocation}/wing`);
-
-                break;
-            case 9:
-                browserHistory.push(`${drawerLocation}/details`);
-
-                break;
-            case 10:
-                browserHistory.push(`${drawerLocation}/sticky`);
-
-                break;
-        }
-    }
 }
 
 export default ModulesDrawerSubNavigation;

--- a/docs/src/modules/pageDemo.js
+++ b/docs/src/modules/pageDemo.js
@@ -250,7 +250,7 @@ class PageDemo extends React.PureComponent {
                                                 promptColor: 'success',
                                                 promptMessage: 'Create a new Quux Template?  For reals?',
                                                 requiresPrompt: true,
-                                            }
+                                            },
                                         ],
                                     }, {
                                         iconType: 'envelope',

--- a/docs/src/modules/pageDemo.js
+++ b/docs/src/modules/pageDemo.js
@@ -6,7 +6,7 @@ import {
     TitleBar,
 } from 'react-cm-ui';
 import _ from 'lodash';
-import { backgroundColorSuccess } from 'shared/styles/colors.scss';
+import { backgroundColorAlert, backgroundColorSuccess } from 'shared/styles/colors.scss';
 import { connect } from 'react-redux'; // eslint-disable-line import/no-extraneous-dependencies
 import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
@@ -242,7 +242,15 @@ class PageDemo extends React.PureComponent {
                                                 id: 'sub-option-baz',
                                                 label: 'Baz Template',
                                                 onClick: () => { console.log('Bar Template was clicked!'); /* eslint-disable-line no-console */ },
-                                            },
+                                            }, {
+                                                iconType: 'wrench-screwdriver',
+                                                id: 'sub-option-quux',
+                                                label: 'Quux Template',
+                                                onClick: () => { console.log('Quux Template was clicked!'); /* eslint-disable-line no-console */ },
+                                                promptColor: 'success',
+                                                promptMessage: 'Create a new Quuz Template?  For reals?',
+                                                requiresPrompt: true,
+                                            }
                                         ],
                                     }, {
                                         iconType: 'envelope',
@@ -253,6 +261,14 @@ class PageDemo extends React.PureComponent {
                                         iconType: 'comment-lines',
                                         label: 'SMS',
                                         onClick: () => { console.log('SMS was clicked!'); /* eslint-disable-line no-console */ },
+                                    }, {
+                                        iconType: 'times',
+                                        label: 'Delete Stuff',
+                                        iconBackgroundColor: backgroundColorAlert,
+                                        onClick: () => { console.log('Deleting all the things!'); /* eslint-disable-line no-console */ },
+                                        promptColor: 'alert',
+                                        promptMessage: 'Really delete all the things?  No joke?',
+                                        requiresPrompt: true,
                                     },
                                 ],
                             },

--- a/docs/src/modules/pageDemo.js
+++ b/docs/src/modules/pageDemo.js
@@ -248,7 +248,7 @@ class PageDemo extends React.PureComponent {
                                                 label: 'Quux Template',
                                                 onClick: () => { console.log('Quux Template was clicked!'); /* eslint-disable-line no-console */ },
                                                 promptColor: 'success',
-                                                promptMessage: 'Create a new Quuz Template?  For reals?',
+                                                promptMessage: 'Create a new Quux Template?  For reals?',
                                                 requiresPrompt: true,
                                             }
                                         ],

--- a/docs/src/modules/prompt.js
+++ b/docs/src/modules/prompt.js
@@ -101,7 +101,7 @@ export default class OptionalPromptSample extends React.Component {
     }
 
     _onNoClick() {
-        console.log('No ... just kidding.  Don\'t delete it!');
+        console.log('No ... just kidding.  Don\\'t delete it!');
         this.setState({ showPrompt: false });
     }
 }`;

--- a/src/modules/actionBar.scss
+++ b/src/modules/actionBar.scss
@@ -271,6 +271,9 @@ $backwards-step4-duration: $standard-fifth-timing;
             padding-top: 11px;
         }
     }
+    .action_bar--actions_button {
+        margin-right: 0;
+    }
 }
 
 @media only screen and (max-width: 767px) {

--- a/src/modules/actionBarActionsButtonDrawerOption.js
+++ b/src/modules/actionBarActionsButtonDrawerOption.js
@@ -3,77 +3,10 @@ import _ from 'lodash';
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ActionBarActionsButtonDrawerSubOption, {
+    singleOptionPropTypeShape,
+} from './actionBarActionsButtonDrawerSubOption.js';
 import Icon from '../elements/icon.js';
-import Utils from '../utils/utils.js';
-
-const nop = () => {};
-
-function ActionBarActionsButtonDrawerSubOption({
-    isSelected,
-    subOption,
-    subOptionClassNameNum,
-}) {
-    const classNameNumber = subOptionClassNameNum;
-    const subOptionClasses = ClassNames(
-        'actions_button_drawer--sub_option',
-        `actions_button_drawer--sub_option-${classNameNumber}`,
-        `${isSelected ? `actions_button_drawer--sub_option-${classNameNumber}-show` : ''}`,
-        `${subOption.disabled ? `actions_button_drawer--sub_option-${classNameNumber}-disabled` : ''}`,
-    );
-
-    const subOptionOnClick = _.isFunction(subOption.onClick) && !subOption.disabled ?
-        subOption.onClick :
-        nop;
-
-    /* eslint-disable jsx-a11y/interactive-supports-focus,jsx-a11y/click-events-have-key-events */
-    return (
-        <div
-            className={subOptionClasses}
-            onClick={subOptionOnClick}
-            role="menuitem"
-        >
-            <div
-                className="actions_button_drawer_sub_option--icon_container"
-                id={subOption.id}
-            >
-                <Icon
-                    color={subOption.disabled ? 'static' : subOption.iconColor}
-                    compact
-                    className="actions_button_drawer_sub_option--icon"
-                    size={subOption.iconSize || 16}
-                    type={subOption.iconType}
-                />
-            </div>
-
-            <div
-                className="actions_button_drawer_sub_option--label"
-            >
-                {subOption.label}
-            </div>
-        </div>
-    );
-    /* eslint-enable jsx-a11y/interactive-supports-focus,jsx-a11y/click-events-have-key-events */
-}
-
-const singleOptionPropTypeShape = {
-    disable: PropTypes.bool,
-    id: PropTypes.string,
-    iconBackgroundColor: PropTypes.string,
-    iconColor: PropTypes.string,
-    iconSize: PropTypes.oneOfType([
-        PropTypes.oneOf(Utils.sizeEnums()),
-        PropTypes.number,
-    ]),
-    iconType: PropTypes.string,
-    label: PropTypes.string,
-    onClick: PropTypes.func,
-};
-
-ActionBarActionsButtonDrawerSubOption.propTypes = {
-    isSelected: PropTypes.bool.isRequired,
-    subOption: PropTypes.shape(singleOptionPropTypeShape).isRequired,
-    subOptionClassNameNum: PropTypes.number.isRequired,
-};
 
 class ActionBarActionsButtonDrawerOption extends React.PureComponent {
     constructor() {
@@ -83,11 +16,23 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
     }
 
     onParentClick() {
-        const { isSelected, onClick, option } = this.props;
+        const {
+            isSelected,
+            onClick,
+            onRequestPrompt,
+            option,
+        } = this.props;
 
         if (_.isFunction(option.onClick)) {
             if (option.disabled) {
                 return false;
+            }
+
+            if (option.requiresPrompt) {
+                if (_.isFunction(onRequestPrompt)) {
+                    onRequestPrompt(option);
+                    return false;
+                }
             }
 
             option.onClick();
@@ -103,6 +48,7 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
             hide,
             idNumber,
             isSelected,
+            onRequestPrompt,
             option,
         } = this.props;
 
@@ -175,6 +121,7 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
                                 <ActionBarActionsButtonDrawerSubOption
                                     isSelected={isSelected}
                                     key={`actions_button_drawer_sub_option-${subOptionKeyNum++/* eslint-disable-line no-plusplus */}`}
+                                    onRequestPrompt={onRequestPrompt}
                                     subOption={subOption}
                                     subOptionClassNameNum={classNameNumber}
                                 />
@@ -198,6 +145,7 @@ ActionBarActionsButtonDrawerOption.propTypes = {
     idNumber: PropTypes.number,
     isSelected: PropTypes.bool,
     onClick: PropTypes.func.isRequired,
+    onRequestPrompt: PropTypes.func,
     option: PropTypes.shape(rootOptionPropTypeShape).isRequired,
 };
 
@@ -205,6 +153,7 @@ ActionBarActionsButtonDrawerOption.defaultProps = {
     hide: false,
     idNumber: false,
     isSelected: false,
+    onRequestPrompt: undefined,
 };
 
 export default ActionBarActionsButtonDrawerOption;

--- a/src/modules/actionBarActionsButtonDrawerSubOption.js
+++ b/src/modules/actionBarActionsButtonDrawerSubOption.js
@@ -1,0 +1,118 @@
+import _ from 'lodash';
+import ClassNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Icon from '../elements/icon.js';
+import Utils from '../utils/utils.js';
+
+class ActionBarActionsButtonDrawerSubOption extends React.PureComponent {
+    constructor() {
+        super();
+        this.onClick = this.onClick.bind(this);
+    }
+
+    onClick() {
+        const {
+            onRequestPrompt,
+            subOption,
+            subOption: {
+                disabled,
+                onClick: subOptionOnClick,
+                requiresPrompt,
+            },
+        } = this.props;
+
+        if (!_.isFunction(subOptionOnClick)) {
+            return false;
+        }
+
+        if (disabled) {
+            return false;
+        }
+
+        if (requiresPrompt && _.isFunction(onRequestPrompt)) {
+            onRequestPrompt(subOption);
+            return false;
+        }
+
+        subOptionOnClick();
+        return true;
+    }
+
+    render() {
+        const {
+            isSelected,
+            subOption,
+            subOptionClassNameNum,
+        } = this.props;
+
+        const classNameNumber = subOptionClassNameNum;
+        const subOptionClasses = ClassNames(
+            'actions_button_drawer--sub_option',
+            `actions_button_drawer--sub_option-${classNameNumber}`,
+            `${isSelected ? `actions_button_drawer--sub_option-${classNameNumber}-show` : ''}`,
+            `${subOption.disabled ? `actions_button_drawer--sub_option-${classNameNumber}-disabled` : ''}`,
+        );
+
+        /* eslint-disable jsx-a11y/click-events-have-key-events */
+        /* eslint-disable jsx-a11y/interactive-supports-focus */
+        return (
+            <div
+                className={subOptionClasses}
+                onClick={this.onClick}
+                role="menuitem"
+            >
+                <div
+                    className="actions_button_drawer_sub_option--icon_container"
+                    id={subOption.id}
+                >
+                    <Icon
+                        color={subOption.disabled ? 'static' : subOption.iconColor}
+                        compact
+                        className="actions_button_drawer_sub_option--icon"
+                        size={subOption.iconSize || 16}
+                        type={subOption.iconType}
+                    />
+                </div>
+
+                <div
+                    className="actions_button_drawer_sub_option--label"
+                >
+                    {subOption.label}
+                </div>
+            </div>
+        );
+        /* eslint-enable jsx-a11y/click-events-have-key-events */
+        /* eslint-enable jsx-a11y/interactive-supports-focus */
+    }
+}
+
+export const singleOptionPropTypeShape = {
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    iconBackgroundColor: PropTypes.string,
+    iconColor: PropTypes.string,
+    iconSize: PropTypes.oneOfType([
+        PropTypes.oneOf(Utils.sizeEnums()),
+        PropTypes.number,
+    ]),
+    iconType: PropTypes.string,
+    label: PropTypes.string,
+    onClick: PropTypes.func,
+    promptColor: PropTypes.string,
+    promptMessage: PropTypes.string,
+    requiresPrompt: PropTypes.bool,
+};
+
+ActionBarActionsButtonDrawerSubOption.propTypes = {
+    isSelected: PropTypes.bool.isRequired,
+    onRequestPrompt: PropTypes.func,
+    subOption: PropTypes.shape(singleOptionPropTypeShape).isRequired,
+    subOptionClassNameNum: PropTypes.number.isRequired,
+};
+
+ActionBarActionsButtonDrawerSubOption.defaultProps = {
+    onRequestPrompt: undefined,
+};
+
+export default ActionBarActionsButtonDrawerSubOption;

--- a/src/modules/details.scss
+++ b/src/modules/details.scss
@@ -11,11 +11,11 @@ $prefixPageDetails: page--details;
             &-columns-container {
                 display: flex;
                 flex-wrap: wrap;
-                margin: 0 -16px;
+                margin: 0 -11px;
                 > {
                     .#{$prefixDrawerDetails}, .#{$prefixPageDetails} {
                         &-column {
-                            padding: 0 16px 11px;
+                            padding: 0 11px 11px;
                             &.divide {
                                 display: flex;
                                 margin-left: 16px;
@@ -46,6 +46,16 @@ $prefixPageDetails: page--details;
         &.#{$prefixDrawerDetails}, &.#{$prefixPageDetails} {
             .ui.info-bar {
                 padding: 22px;
+            }
+            &-columns-container {
+                margin: 0 -16px;
+            }
+            > {
+                .#{$prefixDrawerDetails}, .#{$prefixPageDetails} {
+                    &-column {
+                        padding: 0 16px 11px;
+                    }
+                }
             }
         }
     }

--- a/src/modules/drawer.js
+++ b/src/modules/drawer.js
@@ -1,20 +1,20 @@
 import _ from 'lodash';
 import ClassNames from 'classnames';
-import DOMUtils from '../utils/domUtils.js';
-import DrawerActionBar from './drawerActionBar.js';
-import DrawerContent from './drawerContent.js';
-import DrawerDetails from './drawerDetails.js';
-import DrawerFiltersDrawer from './drawerFiltersDrawer.js';
-import DrawerGrid from './drawerGrid.js';
-import DrawerNavigation from './drawerNavigation.js';
-import DrawerTable from './drawerTable.js';
-import DrawerTitleBar from './drawerTitleBar.js';
-import DrawerWing from './drawerWing.js';
 import { Portal } from 'react-portal';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ScrollBar from 'react-custom-scrollbars';
+import DOMUtils from '../utils/domUtils.js';
+import DrawerActionBar from './drawerActionBar.js'; // eslint-disable-line import/no-cycle
+import DrawerContent from './drawerContent.js';
+import DrawerDetails from './drawerDetails.js';
+import DrawerFiltersDrawer from './drawerFiltersDrawer.js'; // eslint-disable-line import/no-cycle
+import DrawerGrid from './drawerGrid.js';
+import DrawerNavigation from './drawerNavigation.js';
+import DrawerTable from './drawerTable.js';
+import DrawerTitleBar from './drawerTitleBar.js';
+import DrawerWing from './drawerWing.js';
 
 const BODY = document.body;
 const TRANSLATE_X_END = 'translateX(0)';
@@ -321,9 +321,11 @@ class Drawer extends React.Component {
                 BODY.style.top = `-${scrollPosition}px`;
 
                 DOMUtils.addClassName(BODY, 'drawer-open');
+
                 if (positionY && maxHeight) {
                     BODY.style.position = 'inherit';
                 }
+
                 this._shadowRef.style.boxShadow = `${boxShadowPositionX}${boxShadow}`;
                 nodePortal.style.zIndex = zIndex - 1;
                 this._drawerContainer.style.zIndex = zIndex + drawerLength;

--- a/src/modules/prompt.js
+++ b/src/modules/prompt.js
@@ -80,7 +80,8 @@ class Prompt extends Component {
         const { children } = this.props;
         const { show } = this.state;
 
-        const promptActionClasses = ClassNames('prompt-action', {
+        const childClasses = (children && children.props.className) || null;
+        const promptActionClasses = ClassNames('prompt-action', childClasses, {
             'prompt-action-disable': show,
         });
 

--- a/src/modules/prompt.js
+++ b/src/modules/prompt.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, { Component } from 'react';
 import _ from 'lodash';
 import ClassNames from 'classnames';
@@ -12,18 +10,103 @@ class Prompt extends Component {
 
         this.state = {
             show: props.show || false,
-            inlineVerticalAlign: 0
+            inlineVerticalAlign: 0,
         };
 
-        this._onClick = this._onClick.bind(this);
-        this._onNoClick = this._onNoClick.bind(this);
-        this._onYesClick = this._onYesClick.bind(this);
+        this.onClick = this.onClick.bind(this);
+        this.onNoClick = this.onNoClick.bind(this);
+        this.onYesClick = this.onYesClick.bind(this);
+    }
+
+    componentDidMount() {
+        const { inline } = this.props;
+
+        if (inline) {
+            this.findInlineVerticalPosition();
+        }
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.show !== prevProps.show) {
-            this.setState({ show: this.props.show });
+        const { show: nextShowProp } = this.props;
+        const { show: prevShowProp } = prevProps;
+
+        if (nextShowProp !== prevShowProp) {
+            this.setState({ show: nextShowProp });
         }
+    }
+
+    onClick(option) {
+        const { onClick } = this.props;
+        const { show } = this.state;
+
+        if (show) { return false; }
+
+        if (!_.isUndefined(onClick)) {
+            onClick(option);
+        } else {
+            this.setState({ show: true });
+        }
+
+        return false;
+    }
+
+    onNoClick() {
+        const { onNoClick } = this.props;
+
+        if (!_.isUndefined(onNoClick)) {
+            onNoClick();
+        } else {
+            this.setState({ show: false });
+        }
+    }
+
+    onYesClick() {
+        const { onYesClick } = this.props;
+
+        if (!_.isUndefined(onYesClick)) {
+            onYesClick();
+        } else {
+            this.setState({ show: false });
+        }
+    }
+
+    findInlineVerticalPosition() {
+        const childHeight = ReactDOM.findDOMNode(this.promptAction).offsetHeight; // eslint-disable-line max-len, react/no-find-dom-node
+        const negativeSpace = 5;
+        this.setState({ inlineVerticalAlign: `${childHeight + negativeSpace}px` });
+    }
+
+    renderAction() {
+        const { children } = this.props;
+        const { show } = this.state;
+
+        const promptActionClasses = ClassNames('prompt-action', {
+            'prompt-action-disable': show,
+        });
+
+        if (children && children.type.name === 'Button') {
+            return React.cloneElement(children, {
+                className: promptActionClasses,
+                color: show ? 'disable' : children.props.color,
+                onClick: this.onClick,
+                ref: (promptAction) => { this.promptAction = promptAction; },
+            });
+        }
+
+        if (children && children.type.name === 'Dropdown') {
+            return React.cloneElement(children, {
+                className: promptActionClasses,
+                buttonColor: show && children.props.buttonColor !== 'transparent' ? 'disable' : children.props.buttonColor,
+                onChange: this.onClick,
+                ref: (promptAction) => { this.promptAction = promptAction; },
+            });
+        }
+
+        return React.cloneElement(children, {
+            className: `${promptActionClasses} ${show ? 'color-static' : null}`,
+            onClick: this.onClick,
+            ref: (promptAction) => { this.promptAction = promptAction; },
+        });
     }
 
     render() {
@@ -35,117 +118,56 @@ class Prompt extends Component {
             inlineHorizontalAlign,
             inlineMessageColor,
             message,
-            style
+            style,
         } = this.props;
+
         const { show, inlineVerticalAlign } = this.state;
         const containerClasses = ClassNames('ui', 'prompt', className, {
             'prompt-show': show,
-            'prompt-inline': inline
+            'prompt-inline': inline,
         });
+
         const messageClasses = ClassNames('prompt-message', {
             'promp-message-alert': inlineMessageColor === 'alert' || children.props.color === 'alert' || children.props.buttonColor === 'alert',
-            'promp-message-success': inlineMessageColor === 'success' || children.props.color === 'success' || children.props.buttonColor === 'success'
+            'promp-message-success': inlineMessageColor === 'success' || children.props.color === 'success' || children.props.buttonColor === 'success',
         });
+
         const promptActionsStyle = {
             left: !inlineHorizontalAlign || inlineHorizontalAlign === 'left' ? 0 : null,
             right: inlineHorizontalAlign === 'right' ? 0 : null,
-            top: inlineVerticalAlign
+            top: inlineVerticalAlign,
         };
 
         return (
             <div className={containerClasses} id={id} style={style}>
-                {this._renderAction()}
+                {this.renderAction()}
 
                 <div className="prompt-actions" style={promptActionsStyle}>
-                    <div className={messageClasses}>{message || 'Are you sure?'}</div>
-                    <a className="prompt-yes-btn" onClick={this._onYesClick}>{'Yes'}</a>
-                    <a className="prompt-no-btn" onClick={this._onNoClick}>{'No'}</a>
+                    <div className={messageClasses}>{message}</div>
+                    {/* eslint-disable max-len */}
+                    {/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/anchor-is-valid */}
+                    <a className="prompt-yes-btn" onClick={this.onYesClick}>Yes</a>
+                    <a className="prompt-no-btn" onClick={this.onNoClick}>No</a>
+                    {/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/anchor-is-valid */}
+                    {/* eslint-enable max-len */}
                 </div>
             </div>
         );
     }
-
-    componentDidMount() {
-        if (this.props.inline) {
-            this._findInlineVerticalPosition();
-        }
-    }
-
-    _findInlineVerticalPosition() {
-        const childHeight = ReactDOM.findDOMNode(this.promptAction).offsetHeight;
-        const negativeSpace = 5;
-        this.setState({ inlineVerticalAlign: childHeight + negativeSpace + 'px' });
-    }
-
-    _onClick(option) {
-        const { onClick } = this.props;
-        const { show } = this.state;
-
-        if (show) { return false; }
-
-        if (!_.isUndefined(onClick)) {
-            onClick(option);
-        } else {
-            this.setState({ show: true });
-        }
-    }
-
-    _onNoClick() {
-        const { onNoClick } = this.props;
-
-        if (!_.isUndefined(onNoClick)) {
-            onNoClick();
-        } else {
-            this.setState({ show: false });
-        }
-    }
-
-    _onYesClick() {
-        const { onYesClick } = this.props;
-
-        if (!_.isUndefined(onYesClick)) {
-            onYesClick();
-        } else {
-            this.setState({ show: false });
-        }
-    }
-
-    _renderAction() {
-        const { children } = this.props;
-        const { show } = this.state;
-        const promptActionClasses = ClassNames('prompt-action', {
-            'prompt-action-disable': show
-        });
-
-        if (children && children.type.name === 'Button') {
-            return React.cloneElement(children, {
-                className: promptActionClasses,
-                color: show ? 'disable' : children.props.color,
-                onClick: this._onClick.bind(this),
-                ref: promptAction => { this.promptAction = promptAction; },
-            });
-        } else if (children && children.type.name === 'Dropdown') {
-            return React.cloneElement(children, {
-                className: promptActionClasses,
-                buttonColor: show && children.props.buttonColor !== 'transparent' ? 'disable' : children.props.buttonColor,
-                onChange: this._onClick.bind(this),
-                ref: promptAction => { this.promptAction = promptAction; },
-            });
-        } else {
-            return React.cloneElement(children, {
-                className: `${promptActionClasses} ${show ? 'color-static' : null}`,
-                onClick: this._onClick.bind(this),
-                ref: promptAction => { this.promptAction = promptAction; },
-            });
-        }
-    }
 }
 
-const inlineHorizontalAlign = [ 'left', 'right' ];
-const inlineMessageColor = [ 'alert', 'success' ];
+const inlineHorizontalAlign = ['left', 'right'];
+const inlineMessageColor = ['alert', 'success'];
 
 Prompt.propTypes = {
-    className: PropTypes.string,
+    className: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.shape({}),
+    ]),
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
     id: PropTypes.string,
     inline: PropTypes.bool,
     inlineHorizontalAlign: PropTypes.oneOf(inlineHorizontalAlign),
@@ -154,7 +176,23 @@ Prompt.propTypes = {
     onClick: PropTypes.func,
     onNoClick: PropTypes.func,
     onYesClick: PropTypes.func,
-    style: PropTypes.object,
+    style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    show: PropTypes.bool,
+};
+
+Prompt.defaultProps = {
+    className: undefined,
+    children: null,
+    id: undefined,
+    inline: false,
+    inlineHorizontalAlign: 'left',
+    inlineMessageColor: undefined,
+    message: 'Are you sure?',
+    onClick: undefined,
+    onNoClick: undefined,
+    onYesClick: undefined,
+    style: undefined,
+    show: undefined,
 };
 
 export default Prompt;


### PR DESCRIPTION
Build Prompt functionality into `<Page.ActionsBar />` (specifically the `<ActionBarActionsButton />` for the mobile actions menu) so that various options or sub-options can request and configure a confirmation prompt before their `onClick` action is actually fired.

![image](https://user-images.githubusercontent.com/4349658/66430243-8c6d0300-e9ce-11e9-9a10-a9d03fe23571.png)

![image](https://user-images.githubusercontent.com/4349658/66430260-92fb7a80-e9ce-11e9-9512-9067bfa2c1b1.png)

![image](https://user-images.githubusercontent.com/4349658/66430345-bcb4a180-e9ce-11e9-8e8c-c10a84599b37.png)

![image](https://user-images.githubusercontent.com/4349658/66432312-a0b2ff00-e9d2-11e9-80f3-9251fe4b9fda.png)

