### PR TITLE
Fix Regression due to 'sticky drawer' feature

### DIFF
--- a/src/modules/drawer.js
+++ b/src/modules/drawer.js
@@ -398,7 +398,7 @@ Drawer.defaultProps = {
     dimmer: true,
     isOpen: false,
     positionX: 'right',
-    positionY: 'top',
+    positionY: undefined,
 };
 
 Drawer.propTypes = {


### PR DESCRIPTION
`<Drawer />` component's new `positionY` prop should only be set to "top" or "bottom" if the new sticky drawer behavior is desired.  It must default to not being set at all.  Having it default to "top" was preventing the "nested toggles" in the page mobile filters drawer from being visible, due to `overflow: hidden;` in the CSS for the sticky drawer.