### PR TITLE
[dev] Add `formatShortWithSpecifiedTz()` function to `DateUtils`

### DIFF
--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -23,7 +23,7 @@ const DateUtils = {
     formatForCommentsWithTz(data, userTimeZoneId) {
         const timeZoneId = userTimeZoneId || DateUtils.getDetectedTimeZone();
 
-        if (data === null || typeof data === 'undefined') {
+        if (_.isNil(data)) {
             return null;
         }
 
@@ -107,15 +107,27 @@ const DateUtils = {
     },
 
     formatShort(data) {
-        if (data === null || typeof data === 'undefined') {
+        if (_.isNil(data)) {
             return null;
         }
 
         if (_.isNumber(data)) {
-            return moment.unix(data).utc().format('MM/DD/YY');
+            return moment.unix(data).utc().format('MM/DD/YY'); // TODO/FIXME: Consider using L (although that has a 4 digit year, i.e. YYYY)
         }
 
-        return moment(data).format('MM/DD/YY');
+        return moment(data).format('MM/DD/YY'); // TODO/FIXME: Consider using L (although that has a 4 digit year, i.e. YYYY)
+    },
+
+    formatShortWithSpecifiedTz(data, timeZoneId) {
+        if (_.isNil(data)) {
+            return null;
+        }
+
+        if (_.isNumber(data)) {
+            return moment.unix(data).utc().tz(timeZoneId).format('MM/DD/YY'); // TODO/FIXME: Consider using L (although that has a 4 digit year, i.e. YYYY)
+        }
+
+        return moment(data).tz(timeZoneId).format('MM/DD/YY'); // TODO/FIXME: Consider using L (although that has a 4 digit year, i.e. YYYY)
     },
 
     formatDayOfWeek(data) {


### PR DESCRIPTION
Also:
* Standardize on `_.isNil(foo)` over `foo === null || typeof foo === 'undefined` in a couple of other functions
* Add `TODO/FIXME` comments in `formatShort()` function and new `formatShortWithSpecifiedTz()` function to indicate that using a built-in format pattern with localization support is preferable, but that the nearest one to our hard-coded format uses 4 digit years rather than 2 digit years.  We should definitely note, however, that hard-coding MM/DD/YY is not the best, esp. from a localization standpoint, since many cultures have different conventions (e.g. month and day segments might be swapped).