### PR TITLE
[dev] [No PBI] Fix Avatar Image in Comment component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cm-ui",
-  "version": "7.0.0",
+  "version": "7.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/saddlebackdev/react-cm-ui#readme",
   "scripts": {
     "build": "webpack",
+    "build:clean": "rimraf docs/build",
     "build:local": "webpack-dev-server --mode development --content-base docs/build/ --hot --progress --colors --host 0.0.0.0",
     "build:prod": "npm run build",
     "build:stats": "webpack --display-modules --display-chunks --json > stats.json --progress",
@@ -38,7 +39,8 @@
     "compile": "npm run clean:lib && gulp && cpx \"src/shared/images/**\" \"lib/shared/images\" && babel src/ -d lib/",
     "postpublish": "git checkout master && git push && git checkout dev",
     "prepare": "npm run compile",
-    "start": "npm run build:local"
+    "start": "npm run build:local",
+    "start:prod": "webpack-dev-server --mode production --content-base docs/build/  --progress --colors --host 0.0.0.0"
   },
   "dependencies": {
     "autosize": "^3.0.17",

--- a/src/elements/comment.js
+++ b/src/elements/comment.js
@@ -52,7 +52,7 @@ class Comment extends Component {
                         }}
                     >
                         <div style={{ flex: 'none' }}>
-                            <Image avatar name={name} size={44} src={avatarSrc} />
+                            <Image type="user" name={name} size={44} src={avatarSrc} />
                         </div>
 
                         <div


### PR DESCRIPTION
**Main fix:**
* Update the "avatar" image embedded in `<Comment />` (we missed this when we refactored `<Image />` to use `type` prop rather than `avatar` prop).

**Also Fixed:**
* Update version in `package-lock.json`
* Add some `npm` commands to `package.json` to be able to run in production mode

**Side Note/Open Issue:**
So, I noticed something _extremely bizarre_, having to to do with `<Dropdown />` when used as a "button menu thingie" and `<Prompt />`.  On the UI Documentation website, the samples where a `<Dropdown />` button menu thingie should trigger the `<Prompt />` _don't work!_
See:
http://cm-ui-docs.saddleback.com/modules/prompt
http://cm-ui-docs.saddleback.com/elements/comment#editable-comment

However (and this is the really bizarre part):
* It works okay when running CM UI Docs locally, and
* _It works in deployed HC_ (e.g. I tested Comments in My Dashboard/Follow Ups on HC-Stage ... working just fine all day, thank God!)

That last point is the biggest head-scratcher here in my opinion; why does it work in deployed HC builds but not production CM UI Docs builds?

Using the new `npm run start:prod` command I introduced in this change set, I can reproduce the problem locally.  So, good news on the issue reproduciblity front, but the issue itself remains a mystery (I haven't really dug in yet).

Probably not a showstopper, since it is mitigated by the fact that is working in deployed HC builds for whatever reason (otherwise we'd have likely heard about this by now from end-users).  I'm not at all sure at which point this regressed.  It's a little bad that it doesn't work right on the documentation website, but likely not the hottest burning fire in terms of priority.