### PR TITLE
[dev] AB#25758 - RB: [Person Record 2.0] [page] [lg - xl] - Notes: Drawer’s max width needs to never be greater than the inside of the page gutter (All Browsers)

### DIFF
--- a/src/templates/drawer.jsx
+++ b/src/templates/drawer.jsx
@@ -118,6 +118,24 @@ class Drawer extends React.Component {
                 `${TRANSLATE_X_END} translateY(${nextProps.positionYOffset}px)` :
                 TRANSLATE_X_END;
         }
+        
+        if (
+            prevProps.isOpen &&
+            nextProps.isOpen &&
+            prevProps.maxWidth !== nextProps.maxWidth
+        ) {
+            this.drawerContainerRef.style.maxWidth = _.isNumber(nextProps.maxWidth) ? `${nextProps.maxWidth}px` :
+                nextProps.maxWidth || '768px';
+        }
+        
+        if (
+            prevProps.isOpen &&
+            nextProps.isOpen &&
+            prevProps.maxHeight !== nextProps.maxHeight
+        ) {
+            this.drawerContainerRef.style.maxHeight = _.isNumber(nextProps.maxHeight) ? `${nextProps.maxHeight}px` :
+                nextProps.maxHeight || '700px';
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
PR contains

- Ability to change drawers width/height whenever `maxwidth` and `maxHeight` props are updated. Initially, maxWidth and maxHeight was being considered only on drawer open.