### PR TITLE
[dev] AB#25753 - [Person Record 2.0] [page] [md] - Notes: Need to use mobile notes drawer UX. (All Browsers) 

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reacm-cm-ui-docs",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "reacm-cm-ui-docs",
+  "name": "react-cm-ui-docs",
   "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/templates/drawer.jsx
+++ b/src/templates/drawer.jsx
@@ -29,7 +29,6 @@ const propTypes = {
         PropTypes.number,
         PropTypes.string,
     ]),
-    mobileMaxWidth: PropTypes.number,
     onClickOutside: PropTypes.bool,
     onClose: PropTypes.func,
     onCloseComplete: PropTypes.func,
@@ -48,7 +47,6 @@ const defaultProps = {
     dimmer: true,
     maxHeight: undefined,
     maxWidth: undefined,
-    mobileMaxWidth: undefined,
     onClickOutside: undefined,
     onClose: undefined,
     onCloseComplete: undefined,
@@ -69,8 +67,6 @@ const BOX_SHADOW_XSMALL = '0 0 3px 0 rgba(0, 0, 0, 0.30)';
 const BOX_SHADOW_SMALL = '2px 0 7px 0 rgba(0, 0, 0, 0.17)';
 const BOX_SHADOW_LARGE = '12px 0 19px 0 rgba(0, 0, 0, .22)';
 const DEFAULT_DRAWER_WIDTH = 768;
-const DEFAULT_DRAWER_HEIGHT = 700;
-
 class Drawer extends React.Component {
     constructor(props) {
         super(props);
@@ -137,8 +133,7 @@ class Drawer extends React.Component {
             nextProps.isOpen &&
             prevProps.maxHeight !== nextProps.maxHeight
         ) {
-            this.drawerContainerRef.style.maxHeight = _.isNumber(nextProps.maxHeight) ? `${nextProps.maxHeight}px` :
-                nextProps.maxHeight || `${DEFAULT_DRAWER_HEIGHT}px`;
+            this.drawerContainerRef.style.maxHeight = nextProps.maxHeight ? `${nextProps.maxHeight}px` : 'none';
         }
     }
 
@@ -246,7 +241,6 @@ class Drawer extends React.Component {
         const {
             dimmer,
             maxWidth,
-            mobileMaxWidth,
             maxHeight,
             onClickOutside,
             positionYOffset,
@@ -259,7 +253,6 @@ class Drawer extends React.Component {
         const layeredOffset = 11;
         const scrollPosition = window.pageYOffset;
         const zIndex = 10002; // adding 2 accounts for the frist .drawer and .drawer-dimmers- z-indexes
-        const drawerWidth = mobileMaxWidth ? mobileMaxWidth + 1 : DEFAULT_DRAWER_WIDTH; // This implies if mobileMaxWidth is set and maxWidth not set
 
         this.drawerContainerRef.addEventListener(animationEvent, this.onOpenAnimationComplete);
 
@@ -336,11 +329,11 @@ class Drawer extends React.Component {
                     maxWidth || `${DEFAULT_DRAWER_WIDTH}px`;
             } else {
                 this.drawerContainerRef.style.maxWidth =
-                    `${drawerWidth - (layeredOffset * (drawerLength - 1))}px`;
+                    `${DEFAULT_DRAWER_WIDTH - (layeredOffset * (drawerLength - 1))}px`;
             }
 
             if (!_.isUndefined(maxHeight)) {
-                this.drawerContainerRef.style.maxHeight = maxHeight ? `${maxHeight}px` : `${DEFAULT_DRAWER_HEIGHT}px`;
+                this.drawerContainerRef.style.maxHeight = `${maxHeight}px`;
             }
 
             this.drawerContainerRef.style.transform = _.isNumber(positionYOffset) ?
@@ -390,7 +383,6 @@ class Drawer extends React.Component {
         const {
             children,
             className,
-            mobileMaxWidth,
             positionYOffset,
             wing,
         } = this.props;

--- a/src/templates/drawer.jsx
+++ b/src/templates/drawer.jsx
@@ -423,7 +423,7 @@ class Drawer extends React.Component {
                             autoHide
                         >
                             <div className="drawer-container-inner">
-                                    {children}
+                                {children}
                             </div>
                         </ScrollBar>
 

--- a/src/templates/drawer.jsx
+++ b/src/templates/drawer.jsx
@@ -29,6 +29,7 @@ const propTypes = {
         PropTypes.number,
         PropTypes.string,
     ]),
+    mobileMaxWidth: PropTypes.number,
     onClickOutside: PropTypes.bool,
     onClose: PropTypes.func,
     onCloseComplete: PropTypes.func,
@@ -47,6 +48,7 @@ const defaultProps = {
     dimmer: true,
     maxHeight: undefined,
     maxWidth: undefined,
+    mobileMaxWidth: undefined,
     onClickOutside: undefined,
     onClose: undefined,
     onCloseComplete: undefined,
@@ -66,6 +68,8 @@ const TRANSLATE_X_RIGHT_START = 'translateX(100%)';
 const BOX_SHADOW_XSMALL = '0 0 3px 0 rgba(0, 0, 0, 0.30)';
 const BOX_SHADOW_SMALL = '2px 0 7px 0 rgba(0, 0, 0, 0.17)';
 const BOX_SHADOW_LARGE = '12px 0 19px 0 rgba(0, 0, 0, .22)';
+const DEFAULT_DRAWER_WIDTH = 768;
+const DEFAULT_DRAWER_HEIGHT = 700;
 
 class Drawer extends React.Component {
     constructor(props) {
@@ -125,7 +129,7 @@ class Drawer extends React.Component {
             prevProps.maxWidth !== nextProps.maxWidth
         ) {
             this.drawerContainerRef.style.maxWidth = _.isNumber(nextProps.maxWidth) ? `${nextProps.maxWidth}px` :
-                nextProps.maxWidth || '768px';
+                nextProps.maxWidth || `${DEFAULT_DRAWER_WIDTH}px`;
         }
         
         if (
@@ -134,7 +138,7 @@ class Drawer extends React.Component {
             prevProps.maxHeight !== nextProps.maxHeight
         ) {
             this.drawerContainerRef.style.maxHeight = _.isNumber(nextProps.maxHeight) ? `${nextProps.maxHeight}px` :
-                nextProps.maxHeight || '700px';
+                nextProps.maxHeight || `${DEFAULT_DRAWER_HEIGHT}px`;
         }
     }
 
@@ -242,6 +246,7 @@ class Drawer extends React.Component {
         const {
             dimmer,
             maxWidth,
+            mobileMaxWidth,
             maxHeight,
             onClickOutside,
             positionYOffset,
@@ -254,6 +259,7 @@ class Drawer extends React.Component {
         const layeredOffset = 11;
         const scrollPosition = window.pageYOffset;
         const zIndex = 10002; // adding 2 accounts for the frist .drawer and .drawer-dimmers- z-indexes
+        const drawerWidth = mobileMaxWidth ? mobileMaxWidth + 1 : DEFAULT_DRAWER_WIDTH; // This implies if mobileMaxWidth is set and maxWidth not set
 
         this.drawerContainerRef.addEventListener(animationEvent, this.onOpenAnimationComplete);
 
@@ -327,14 +333,14 @@ class Drawer extends React.Component {
 
             if (!_.isUndefined(maxWidth)) {
                 this.drawerContainerRef.style.maxWidth = _.isNumber(maxWidth) ? `${maxWidth}px` :
-                    maxWidth || '768px';
+                    maxWidth || `${DEFAULT_DRAWER_WIDTH}px`;
             } else {
                 this.drawerContainerRef.style.maxWidth =
-                    `${768 - (layeredOffset * (drawerLength - 1))}px`;
+                    `${drawerWidth - (layeredOffset * (drawerLength - 1))}px`;
             }
 
             if (!_.isUndefined(maxHeight)) {
-                this.drawerContainerRef.style.maxHeight = maxHeight ? `${maxHeight}px` : '700px';
+                this.drawerContainerRef.style.maxHeight = maxHeight ? `${maxHeight}px` : `${DEFAULT_DRAWER_HEIGHT}px`;
             }
 
             this.drawerContainerRef.style.transform = _.isNumber(positionYOffset) ?
@@ -384,6 +390,7 @@ class Drawer extends React.Component {
         const {
             children,
             className,
+            mobileMaxWidth,
             positionYOffset,
             wing,
         } = this.props;
@@ -416,7 +423,7 @@ class Drawer extends React.Component {
                             autoHide
                         >
                             <div className="drawer-container-inner">
-                                {children}
+                                    {children}
                             </div>
                         </ScrollBar>
 

--- a/src/templates/drawerFiltersDrawer.jsx
+++ b/src/templates/drawerFiltersDrawer.jsx
@@ -9,6 +9,7 @@ const propTypes = {
     isDirty: PropTypes.bool.isRequired,
     isFiltering: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool.isRequired,
+    mobileMaxWidth: PropTypes.number,
     onApply: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -20,6 +21,7 @@ const defaultProps = {
     children: undefined,
     className: undefined,
     id: undefined,
+    mobileMaxWidth: undefined,
     rows: undefined,
     style: {},
 };
@@ -32,6 +34,7 @@ function DrawerFiltersDrawer(props) {
         isDirty,
         isFiltering,
         isOpen,
+        mobileMaxWidth,
         onApply,
         onClear,
         onClose,
@@ -46,6 +49,7 @@ function DrawerFiltersDrawer(props) {
             isDirty={isDirty}
             isFiltering={isFiltering}
             isOpen={isOpen}
+            mobileMaxWidth={mobileMaxWidth}
             moduleType="drawer"
             onApply={onApply}
             onClear={onClear}

--- a/src/templates/drawerFiltersDrawer.jsx
+++ b/src/templates/drawerFiltersDrawer.jsx
@@ -3,13 +3,16 @@ import React from 'react';
 import FiltersDrawer from './filtersDrawer'; // eslint-disable-line import/no-cycle
 
 const propTypes = {
+    breakpointDown: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+    ]),
     children: PropTypes.node,
     className: PropTypes.string,
     id: PropTypes.string,
     isDirty: PropTypes.bool.isRequired,
     isFiltering: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool.isRequired,
-    mobileMaxWidth: PropTypes.number,
     onApply: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -18,23 +21,23 @@ const propTypes = {
 };
 
 const defaultProps = {
+    breakpointDown: undefined,
     children: undefined,
     className: undefined,
     id: undefined,
-    mobileMaxWidth: undefined,
     rows: undefined,
     style: {},
 };
 
 function DrawerFiltersDrawer(props) {
     const {
+        breakpointDown,
         children,
         className,
         id,
         isDirty,
         isFiltering,
         isOpen,
-        mobileMaxWidth,
         onApply,
         onClear,
         onClose,
@@ -44,12 +47,12 @@ function DrawerFiltersDrawer(props) {
 
     return (
         <FiltersDrawer
+            breakpointDown={breakpointDown}
             className={className}
             id={id}
             isDirty={isDirty}
             isFiltering={isFiltering}
             isOpen={isOpen}
-            mobileMaxWidth={mobileMaxWidth}
             moduleType="drawer"
             onApply={onApply}
             onClear={onClear}

--- a/src/templates/drawerFiltersRail.jsx
+++ b/src/templates/drawerFiltersRail.jsx
@@ -7,6 +7,7 @@ const propTypes = {
     className: PropTypes.string,
     id: PropTypes.string,
     isOpen: PropTypes.bool,
+    mobileMaxWidth: PropTypes.number,
     style: PropTypes.shape({}),
 };
 
@@ -15,6 +16,7 @@ const defaultProps = {
     className: undefined,
     id: undefined,
     isOpen: undefined,
+    mobileMaxWidth: undefined,
     style: {},
 };
 
@@ -24,6 +26,7 @@ function DrawerFiltersRail(props) {
         className,
         id,
         isOpen,
+        mobileMaxWidth,
         style,
     } = props;
 
@@ -32,6 +35,7 @@ function DrawerFiltersRail(props) {
             className={className}
             id={id}
             isOpen={isOpen}
+            mobileMaxWidth={mobileMaxWidth}
             moduleType="drawer"
             style={style}
         >

--- a/src/templates/drawerFiltersRail.jsx
+++ b/src/templates/drawerFiltersRail.jsx
@@ -3,39 +3,42 @@ import React from 'react';
 import FiltersRail from './filtersRail';
 
 const propTypes = {
+    breakpointUp: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+    ]),
     children: PropTypes.node,
     className: PropTypes.string,
     id: PropTypes.string,
     isOpen: PropTypes.bool,
-    mobileMaxWidth: PropTypes.number,
     style: PropTypes.shape({}),
 };
 
 const defaultProps = {
+    breakpointUp: undefined,
     children: undefined,
     className: undefined,
     id: undefined,
     isOpen: undefined,
-    mobileMaxWidth: undefined,
     style: {},
 };
 
 function DrawerFiltersRail(props) {
     const {
+        breakpointUp,
         children,
         className,
         id,
         isOpen,
-        mobileMaxWidth,
         style,
     } = props;
 
     return (
         <FiltersRail
+            breakpointUp={breakpointUp}
             className={className}
             id={id}
             isOpen={isOpen}
-            mobileMaxWidth={mobileMaxWidth}
             moduleType="drawer"
             style={style}
         >

--- a/src/templates/filtersDrawer.jsx
+++ b/src/templates/filtersDrawer.jsx
@@ -14,14 +14,26 @@ import FiltersDrawerNestedTogglesWingOptionLabel from './filtersDrawerNestedTogg
 import Header from '../atoms/header';
 import Icon from '../atoms/icon';
 
+const breakpoints = {
+    values: {
+        sm: 0,
+        md: 767,
+        lg: 1199,
+        xl: 1685,
+    },
+};
+
 const propTypes = {
+    breakpointDown: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+    ]),
     children: PropTypes.node,
     className: PropTypes.string,
     id: PropTypes.string,
     isDirty: PropTypes.bool.isRequired,
     isFiltering: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool.isRequired,
-    mobileMaxWidth: PropTypes.number,
     moduleType: PropTypes.string.isRequired,
     onApply: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
@@ -114,10 +126,10 @@ const propTypes = {
 };
 
 const defaultProps = {
+    breakpointDown: breakpoints.values.md,
     children: undefined,
     className: undefined,
     id: undefined,
-    mobileMaxWidth: undefined,
     rows: undefined,
     style: {},
 };
@@ -213,13 +225,13 @@ class FiltersDrawer extends React.Component {
 
     render() {
         const {
+            breakpointDown,
             children,
             className,
             id,
             isDirty,
             isFiltering,
             isOpen,
-            mobileMaxWidth,
             moduleType,
             onClose,
             rows,
@@ -241,13 +253,12 @@ class FiltersDrawer extends React.Component {
 
         return (
             <MediaQuery
-                maxWidth={mobileMaxWidth || 767}
+                maxWidth={breakpointDown}
             >
                 <Drawer
                     className={containerClasses}
                     id={id}
                     isOpen={isOpen}
-                    mobileMaxWidth={mobileMaxWidth}
                     onClose={onClose}
                     style={style}
                     wing={(

--- a/src/templates/filtersDrawer.jsx
+++ b/src/templates/filtersDrawer.jsx
@@ -241,7 +241,7 @@ class FiltersDrawer extends React.Component {
 
         return (
             <MediaQuery
-                maxWidth={mobileMaxWidth ? mobileMaxWidth : 767}
+                maxWidth={mobileMaxWidth || 767}
             >
                 <Drawer
                     className={containerClasses}

--- a/src/templates/filtersDrawer.jsx
+++ b/src/templates/filtersDrawer.jsx
@@ -21,6 +21,7 @@ const propTypes = {
     isDirty: PropTypes.bool.isRequired,
     isFiltering: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool.isRequired,
+    mobileMaxWidth: PropTypes.number,
     moduleType: PropTypes.string.isRequired,
     onApply: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
@@ -116,6 +117,7 @@ const defaultProps = {
     children: undefined,
     className: undefined,
     id: undefined,
+    mobileMaxWidth: undefined,
     rows: undefined,
     style: {},
 };
@@ -217,6 +219,7 @@ class FiltersDrawer extends React.Component {
             isDirty,
             isFiltering,
             isOpen,
+            mobileMaxWidth,
             moduleType,
             onClose,
             rows,
@@ -238,12 +241,13 @@ class FiltersDrawer extends React.Component {
 
         return (
             <MediaQuery
-                maxWidth={767}
+                maxWidth={mobileMaxWidth ? mobileMaxWidth : 767}
             >
                 <Drawer
                     className={containerClasses}
                     id={id}
                     isOpen={isOpen}
+                    mobileMaxWidth={mobileMaxWidth}
                     onClose={onClose}
                     style={style}
                     wing={(

--- a/src/templates/filtersRail.jsx
+++ b/src/templates/filtersRail.jsx
@@ -5,32 +5,44 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Rail from '../organisms/rail';
 
+const breakpoints = {
+    values: {
+        sm: 0,
+        md: 768,
+        lg: 1200,
+        xl: 1686,
+    },
+};
+
 const propTypes = {
+    breakpointUp: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+    ]),
     children: PropTypes.node,
     className: PropTypes.string,
     id: PropTypes.string,
     isOpen: PropTypes.bool,
-    mobileMaxWidth: PropTypes.number,
     moduleType: PropTypes.oneOf(['drawer', 'page']).isRequired,
     style: PropTypes.shape({}),
 };
 
 const defaultProps = {
+    breakpointUp: breakpoints.values.md,
     children: undefined,
     className: undefined,
     id: undefined,
     isOpen: undefined,
-    mobileMaxWidth: undefined,
     style: {},
 };
 
 function FiltersRail(props) {
     const {
+        breakpointUp,
         children,
         className,
         id,
         isOpen,
-        mobileMaxWidth,
         moduleType,
         style,
     } = props;
@@ -42,7 +54,7 @@ function FiltersRail(props) {
 
     return (
         <MediaQuery
-            minWidth={mobileMaxWidth ? mobileMaxWidth + 1 : 768}
+            minWidth={breakpointUp}
         >
             <div
                 className={containerClasses}

--- a/src/templates/filtersRail.jsx
+++ b/src/templates/filtersRail.jsx
@@ -10,6 +10,7 @@ const propTypes = {
     className: PropTypes.string,
     id: PropTypes.string,
     isOpen: PropTypes.bool,
+    mobileMaxWidth: PropTypes.number,
     moduleType: PropTypes.oneOf(['drawer', 'page']).isRequired,
     style: PropTypes.shape({}),
 };
@@ -19,6 +20,7 @@ const defaultProps = {
     className: undefined,
     id: undefined,
     isOpen: undefined,
+    mobileMaxWidth: undefined,
     style: {},
 };
 
@@ -28,6 +30,7 @@ function FiltersRail(props) {
         className,
         id,
         isOpen,
+        mobileMaxWidth,
         moduleType,
         style,
     } = props;
@@ -39,7 +42,7 @@ function FiltersRail(props) {
 
     return (
         <MediaQuery
-            minWidth={768}
+            minWidth={mobileMaxWidth ? mobileMaxWidth + 1 : 768}
         >
             <div
                 className={containerClasses}


### PR DESCRIPTION
PR contains:
- Ability to pass custom prop named `mobileMaxWidth`.  It will enable drawer to show stylings as mobile drawers for viewport less than `mobileMaxWidth`

eg: Person record notes drawer for viewport less than 1018px width, should show mobile styling for notes drawer(Default drawer for mobile styling is 767px)

Note: Right now, I am passing `mobileMaxWidth` props to `drawer`, `FiltersDrawer`, `FilterRails`. For future enhancement, I am thinking of passing only `mobileMaxWidth` props to `drawer`. It can pass it to its children (FiltersDrawer, FilterRails). For that, I was thinking of using `React.context`. Please provide any suggestions/ideas for it.