### PR TITLE
[dev] [No PBI] Add explicit import of things from `@jest/globals` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.8.3",
     "@babel/register": "^7.4.4",
+    "@jest/globals": "^26.0.1",
     "@mvnu/cpx": "^1.5.2",
     "babel-eslint": "^10.0.1",
     "del": "^5.1.0",

--- a/src/atoms/__test__/a.test.js
+++ b/src/atoms/__test__/a.test.js
@@ -2,6 +2,7 @@
  * To Run this test, from the React CM UI root folder, execute the following command:
  * npx jest ./src/atoms/__test__/a.test.js
  */
+import { describe, expect, it } from '@jest/globals';
 import { shallow } from 'enzyme';
 import React from 'react';
 import A from '../a';

--- a/src/atoms/__test__/header.test.js
+++ b/src/atoms/__test__/header.test.js
@@ -2,6 +2,7 @@
  * To Run this test, from the React CM UI root folder, execute the following command:
  * npx jest ./src/atoms/__test__/header.test.js
  */
+import { describe, expect, it } from '@jest/globals';
 import { shallow } from 'enzyme';
 import React from 'react';
 import Header from '../header';


### PR DESCRIPTION
* Adds `@jest/globals` NPM package as a dev dependency
* In each test fixture, adds line: `import { describe, expect, it } from '@jest/globals';`

For some reason, this is necessary to run the tests on my machine.  Otherwise they were failing with error:
```
Test suite failed to run
ReferenceError: describe is not defined
```

No idea as to why this is, since the tests over in `church-management` repo work just fine without this. ¯\\\_(ツ)\_/¯
