### PR TITLE
[dev] BUG AB#27358 [Events Central] - Please remove Phone from the Name column [drill through My Ministry tab]

### DIFF
--- a/src/templates/dataGrid.jsx
+++ b/src/templates/dataGrid.jsx
@@ -106,12 +106,12 @@ class DataGrid extends React.Component {
             currentStickyColumnWidth = theWidth;
         }
 
-        for (let i = 0; i < data.length; i += 1) {
+        if (_.isEmpty(data)) {
             const row = [];
 
             for (let j = 0; j < stickyColumns; j += 1) {
-                const el1 = document.querySelector(`#${this.classNamePrefix}_table_${id}_cell_column-${i}_${j}`);
-                const el2 = document.querySelector(`#${this.classNamePrefix}_table_${id}_cell_body-${i}_${j}`);
+                const el1 = document.querySelector(`#${this.classNamePrefix}_table_${id}_header_column-${j}`);
+                const el2 = document.querySelector(`#${this.classNamePrefix}_table_${id}_header_body-${j}`);
 
                 const size = {
                     h: Math.max(el1.clientHeight, el2.clientHeight),
@@ -126,6 +126,28 @@ class DataGrid extends React.Component {
             }
 
             sizes.push(row);
+        } else {
+            for (let i = 0; i < data.length; i += 1) {
+                const row = [];
+
+                for (let j = 0; j < stickyColumns; j += 1) {
+                    const el1 = document.querySelector(`#${this.classNamePrefix}_table_${id}_cell_column-${i}_${j}`);
+                    const el2 = document.querySelector(`#${this.classNamePrefix}_table_${id}_cell_body-${i}_${j}`);
+
+                    const size = {
+                        h: Math.max(el1.clientHeight, el2.clientHeight),
+                        w: el1.clientWidth,
+                    };
+
+                    if (handle && j === stickyColumns - 1) {
+                        size.w = width;
+                    }
+
+                    row.push(size);
+                }
+
+                sizes.push(row);
+            }
         }
 
         const newState = { currentStickyColumnWidth, sizes };

--- a/src/templates/dataGridTable.jsx
+++ b/src/templates/dataGridTable.jsx
@@ -135,13 +135,30 @@ class DataGridTable extends React.PureComponent {
                                     `${classNamePrefix}_table_header_cell`,
                                     column.className,
                                 );
+                                const cellId = column.id || `${classNamePrefix}_table_${id}_header_${idPrefix}-${index}`;
+
+                                let cellStyle = {};
+                                const cellSize =
+                                    !_.isEmpty(data) || _.isEmpty(sizes) || _.isEmpty(sizes[0]) ?
+                                        null :
+                                        sizes[0][index];
+
+                                if (cellSize) {
+                                    cellStyle.height = `${cellSize.h}px`;
+                                    cellStyle.width = `${cellSize.w}px`;
+                                }
+
+                                cellStyle = {
+                                    ...cellStyle,
+                                    ...column.style,
+                                };
 
                                 return (
                                     <Table.HeaderCell
                                         className={headerCellClasses}
-                                        id={column.id}
+                                        id={cellId}
                                         key={`tableBodyRow-${index}`}
-                                        style={column.style}
+                                        style={cellStyle}
                                     >
                                         {column.header}
 


### PR DESCRIPTION
The issue is that when `DataGrid` has no data the header cell widths are not aligned and we can see the columns of the "sticked table" and the columns of the "scrollable table" at same time. So, this PR should fix that.