### PR TITLE
[dev] Checkbox Bug Fix

### DIFF
--- a/src/inputs/checkbox.jsx
+++ b/src/inputs/checkbox.jsx
@@ -219,9 +219,9 @@ class Checkbox extends React.Component {
                     value={newValue}
                 />
 
+                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
                 <label
                     className={labelClasses}
-                    htmlFor={inputId}
                 >
                     {label && (
                         // eslint-disable-next-line jsx-a11y/no-static-element-interactions


### PR DESCRIPTION
`htmlFor` was removed because when defining an `id` it caused an onChange to be fired twice upon checking/unchecking a Checkbox.