### PR TITLE
[dev] AB#24428 - Added Classes and ID Props to PersonPanel Components

### DIFF
--- a/src/dataDisplay/personPanel/__test__/personPanel.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanel.test.js
@@ -48,9 +48,9 @@ describe('<PersonPanel />', () => {
 
     it('Should render with the root classes', () => {
         const rootOverride = 'makeStyles-root-123';
+
         const wrapper = mount(
             <MockedTheme>
-                cl
                 <PersonPanel
                     {...props}
                     classes={{

--- a/src/dataDisplay/personPanel/__test__/personPanel.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanel.test.js
@@ -22,8 +22,12 @@ describe('<PersonPanel />', () => {
             Details
         </PersonPanelDetails>,
     ];
+
+    const bemName = 'block_name--element_name-modifier';
+
     const props = {
-        id: 'block_name--element_name-modifier',
+        className: bemName,
+        id: bemName,
         isExpanded: false,
         onChange: jest.fn(),
     };
@@ -43,10 +47,15 @@ describe('<PersonPanel />', () => {
     });
 
     it('Should render with the root classes', () => {
+        const rootOverride = 'makeStyles-root-123';
         const wrapper = mount(
             <MockedTheme>
+                cl
                 <PersonPanel
                     {...props}
+                    classes={{
+                        root: rootOverride,
+                    }}
                 >
                     {minimalChildren}
                 </PersonPanel>
@@ -58,6 +67,21 @@ describe('<PersonPanel />', () => {
         expect(root.hasClass('cmui')).toEqual(true);
         expect(root.hasClass('person_panel')).toEqual(true);
         expect(root.hasClass(/(makeStyles)-(root)-(\d+)/)).toEqual(true);
+        expect(root.hasClass(rootOverride)).toEqual(true);
+    });
+
+    it('Should render with the root className', () => {
+        const wrapper = mount(
+            <MockedTheme>
+                <PersonPanel
+                    {...props}
+                />
+            </MockedTheme>,
+        );
+
+        const root = wrapper.find('div').first();
+
+        expect(root.hasClass(props.className)).toEqual(true);
     });
 
     it('Should have expected `id` prop', () => {

--- a/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
@@ -166,6 +166,7 @@ describe('<PersonPanelDetails />', () => {
 
     it('Should render with the root classes', () => {
         const rootOverride = 'makeStyles-root-123';
+
         const wrapper = mount(
             <MockedTheme>
                 <PersonPanelDetails

--- a/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
@@ -165,6 +165,27 @@ describe('<PersonPanelDetails />', () => {
     });
 
     it('Should render with the root classes', () => {
+        const rootOverride = 'makeStyles-root-123';
+        const wrapper = mount(
+            <MockedTheme>
+                <PersonPanelDetails
+                    {...props}
+                    classes={{
+                        root: rootOverride,
+                    }}
+                />
+            </MockedTheme>,
+        );
+
+        const root = wrapper.find('div').first();
+
+        expect(root.hasClass('cmui')).toEqual(true);
+        expect(root.hasClass('person_panel--details')).toEqual(true);
+        expect(root.hasClass(/(makeStyles)-(root)-(\d+)/)).toEqual(true);
+        expect(root.hasClass(rootOverride)).toEqual(true);
+    });
+
+    it('Should render with the root className', () => {
         const wrapper = mount(
             <MockedTheme>
                 <PersonPanelDetails
@@ -175,9 +196,6 @@ describe('<PersonPanelDetails />', () => {
 
         const root = wrapper.find('div').first();
 
-        expect(root.hasClass('cmui')).toEqual(true);
-        expect(root.hasClass('person_panel--details')).toEqual(true);
-        expect(root.hasClass(/(makeStyles)-(root)-(\d+)/)).toEqual(true);
         expect(root.hasClass(props.className)).toEqual(true);
     });
 

--- a/src/dataDisplay/personPanel/__test__/personPanelSummary.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelSummary.test.js
@@ -34,6 +34,7 @@ describe('<PersonPanelSummary />', () => {
 
     it('Should render with the root classes', () => {
         const rootOverride = 'makeStyles-root-123';
+
         const wrapper = mount(
             <MockedTheme>
                 <PersonPanelSummary

--- a/src/dataDisplay/personPanel/__test__/personPanelSummary.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelSummary.test.js
@@ -8,9 +8,13 @@ import MockedTheme from '../../../testUtils/mockedTheme';
 import PersonPanelSummary from '../personPanelSummary';
 
 describe('<PersonPanelSummary />', () => {
+    const bemName = 'block_name--element_name-modifier';
+
     const props = {
         classes: null,
+        className: bemName,
         data: {},
+        id: bemName,
         isExpanded: false,
         onClick: jest.fn(),
         tabIndex: -1,
@@ -29,10 +33,14 @@ describe('<PersonPanelSummary />', () => {
     });
 
     it('Should render with the root classes', () => {
+        const rootOverride = 'makeStyles-root-123';
         const wrapper = mount(
             <MockedTheme>
                 <PersonPanelSummary
                     {...props}
+                    classes={{
+                        root: rootOverride,
+                    }}
                 />
             </MockedTheme>,
         );
@@ -44,6 +52,35 @@ describe('<PersonPanelSummary />', () => {
         expect(root.hasClass(/(makeStyles)-(root)-(\d+)/)).toEqual(true);
         expect(root.hasClass(/(makeStyles)-(genderUndefined)-(\d+)/)).toEqual(true);
         expect(root.hasClass(/(makeStyles)-(isAdult)-(\d+)/)).toEqual(true);
+        expect(root.hasClass(rootOverride)).toEqual(true);
+    });
+
+    it('Should render with the root className', () => {
+        const wrapper = mount(
+            <MockedTheme>
+                <PersonPanelSummary
+                    {...props}
+                />
+            </MockedTheme>,
+        );
+
+        const root = wrapper.find('div').first();
+
+        expect(root.hasClass(props.className)).toEqual(true);
+    });
+
+    it('Should have expected `id` prop', () => {
+        const wrapper = mount(
+            <MockedTheme>
+                <PersonPanelSummary
+                    {...props}
+                />
+            </MockedTheme>,
+        );
+
+        const root = wrapper.find('div').first();
+
+        expect(root.prop('id')).toEqual(props.id);
     });
 
     it('Should render with isStudent class', () => {

--- a/src/dataDisplay/personPanel/personPanel.jsx
+++ b/src/dataDisplay/personPanel/personPanel.jsx
@@ -24,6 +24,10 @@ const propTypes = {
         root: PropTypes.string,
     }),
     /**
+     * Assign additional class names to PersonPanel.
+     */
+    className: PropTypes.string,
+    /**
      * The `id` of the PersonPanel.
      */
     id: PropTypes.string,
@@ -40,6 +44,7 @@ const propTypes = {
 const defaultProps = {
     children: null,
     classes: null,
+    className: null,
     id: null,
     isExpanded: false,
     onChange: null,
@@ -59,13 +64,15 @@ const useStyles = makeStyles({
 function PersonPanel(props) {
     const {
         children,
+        className,
         id,
         isExpanded: isExpandedProp,
         onChange,
     } = props;
 
+    const classes = useStyles(props);
+
     const [isExpanded, setIsExpandedState] = useState(isExpandedProp);
-    const classes = useStyles();
 
     useEffect(() => {
         setIsExpandedState(isExpandedProp);
@@ -110,6 +117,7 @@ function PersonPanel(props) {
         classes.root,
         UI_CLASS_NAME,
         BEM_BLOCK_NAME,
+        className,
     );
 
     return (

--- a/src/dataDisplay/personPanel/personPanelDetails.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetails.jsx
@@ -31,15 +31,15 @@ const propTypes = {
      */
     children: PropTypes.node,
     /**
-     * Assign additional class names to PersonPanelDetails.
-     */
-    className: PropTypes.string,
-    /**
      * Override or extend the styles applied to PersonPanelDetails.
      */
     classes: PropTypes.shape({
         root: PropTypes.string,
     }),
+    /**
+     * Assign additional class names to PersonPanelDetails.
+     */
+    className: PropTypes.string,
     /**
      * The data that the PersonPanelDetails uses to build the UI.
      */
@@ -628,8 +628,6 @@ const useStyles = makeStyles((theme) => {
 });
 
 function PersonPanelDetails(props) {
-    const [dataGroupsColumns, setDataGroupsColumns] = useState([]);
-
     const {
         children,
         className,
@@ -639,6 +637,10 @@ function PersonPanelDetails(props) {
         selectButtonProps,
         viewRecordButtonProps,
     } = props;
+
+    const classes = useStyles(props);
+
+    const [dataGroupsColumns, setDataGroupsColumns] = useState([]);
 
     const {
         addresses,
@@ -752,12 +754,11 @@ function PersonPanelDetails(props) {
         preferredService,
     ]);
 
-    const classes = useStyles(props);
     const rootClasses = ClassNames(
         classes.root,
         UI_CLASS_NAME,
-        className,
         [`${BEM_DETAILS_NAME}`],
+        className,
         {
             [classes.isExpanded]: isExpanded,
         },

--- a/src/dataDisplay/personPanel/personPanelSummary.jsx
+++ b/src/dataDisplay/personPanel/personPanelSummary.jsx
@@ -40,6 +40,10 @@ const propTypes = {
         personId: PropTypes.string,
     }),
     /**
+     * Assign additional class names to PersonPanelSummary.
+     */
+    className: PropTypes.string,
+    /**
      * The data that the PersonPanelSummary uses to build the UI.
      */
     data: PropTypes.shape({
@@ -97,6 +101,10 @@ const propTypes = {
         suffix: PropTypes.string,
     }),
     /**
+     * The `id` of the PersonPanelSummary.
+     */
+    id: PropTypes.string,
+    /**
      * If `true`, expand PersonPanelSummary, otherwise collapse it.
      */
     isExpanded: PropTypes.bool,
@@ -112,7 +120,9 @@ const propTypes = {
 
 const defaultProps = {
     classes: null,
+    className: null,
     data: {},
+    id: null,
     isExpanded: false,
     onClick: () => {},
     tabIndex: -1,
@@ -350,15 +360,20 @@ const useStyles = makeStyles((theme) => {
 });
 
 function PersonPanelSummary(props) {
-    const [metaInfoText, setMetaInfoText] = useState('');
-    const [renderContactInfo, setRenderContactInfo] = useState(null);
-    const classes = useStyles(props);
     const {
+        className,
         data,
+        id,
         isExpanded,
         onClick: onClickProp,
         tabIndex,
     } = props;
+
+    const classes = useStyles(props);
+
+    const [metaInfoText, setMetaInfoText] = useState('');
+    const [renderContactInfo, setRenderContactInfo] = useState(null);
+
     const {
         avatar,
         birthdate,
@@ -386,6 +401,7 @@ function PersonPanelSummary(props) {
         recordType,
         suffix,
     } = data;
+
     const primaryPhone = find(phones, 'isPrimary');
     const primaryEmail = find(emails, 'isPrimary');
     const phone = (primaryPhone && primaryPhone.value) || 'N/A';
@@ -480,6 +496,7 @@ function PersonPanelSummary(props) {
         classes.root,
         UI_CLASS_NAME,
         [`${BEM_CLASS_NAME}`],
+        className,
         {
             [classes.isExpanded]: isExpanded,
             [classes.genderFemale]: includes(['f', 'F'], gender),
@@ -507,6 +524,7 @@ function PersonPanelSummary(props) {
     return (
         <div
             className={rootClasses}
+            id={id}
             onClick={onClick}
             onKeyDown={onKeyDown}
             tabIndex={tabIndex}


### PR DESCRIPTION
Person Panel
- Reordered hooks to have all components read the same.
- Passes in `props` to the `makeStyles` hook so we can override the `root` class in parent components.
- Added `className` prop.
- Added an `expect` in the root classes test to make sure it's rendering the override class.
- Added a test to for `className`

Person Panel Summary
- Reordered hooks to have all components read the same.
- Code clean up
- Added `className` prop.
- Added `id` prop.
- Added an `expect` in the root classes test to make sure it's rendering the override class.
- Added a test to for `className`
- Added a test to for `id`

Person Panel Details
- Reordered hooks to have all components read the same.
- Added `className` prop.
- Code clean up