### PR TITLE
[dev] PBI AB#32635 Ability to create an event - When & Where - [E.1.2] - Recurring Event Re-Design

### DIFF
--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -181,7 +181,7 @@ class DatePickerInput extends React.PureComponent {
         }
     }
 
-    onCalendarChange({ date, dateFrom, dateTo }, isFocused = false) {
+    onCalendarChange({ date, dateFrom, dateTo }) {
         const {
             disable,
             disabled,
@@ -203,11 +203,11 @@ class DatePickerInput extends React.PureComponent {
             });
         }
 
-        this.setOpen(false, isFocused);
+        this.setOpen(false);
     }
 
     onCalendarClickOutside() {
-        this.setOpen(false, false);
+        this.setOpen(false);
     }
 
     onIconClick() {
@@ -276,12 +276,13 @@ class DatePickerInput extends React.PureComponent {
     }
 
     onInputFocus() {
-        this.setOpen(true, true);
+        this.setOpen(true);
+        this.setState({ isFocused: true });
     }
 
     onInputKeyDown(event) {
         if (event.keyCode === 9 || event.keyCode === 13) {
-            this.setOpen(false, true);
+            this.setOpen(false);
         }
     }
 
@@ -315,8 +316,8 @@ class DatePickerInput extends React.PureComponent {
         return minDate;
     }
 
-    setOpen(open, isFocused) {
-        this.setState({ isCalendarOpen: open, isFocused });
+    setOpen(open) {
+        this.setState({ isCalendarOpen: open });
     }
 
     safeDateFormat(date, locale, format = 'MM/DD/YYYY') {

--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -377,7 +377,6 @@ class DatePickerInput extends React.PureComponent {
         }
 
         let inputString = inputValue;
-        // eslint-disable-next-line no-underscore-dangle
         if (!isFocused) {
             const dateFormat = this.safeDateFormat(date, locale, displayFormat);
             if (!isEmpty(dateFormat)) {

--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -267,7 +267,7 @@ class DatePickerInput extends React.PureComponent {
         }
 
         if (isValidValueChange || isValidUpdateToNull) {
-            this.onCalendarChange(onChangeParam, true);
+            this.onCalendarChange(onChangeParam);
         }
     }
 


### PR DESCRIPTION
These changes will allow to have a different displaying format of not focused `DatePickerInput` (displayFormat = 'dddd MM/DD/YYYY'):

Focused:
![Screen Shot 2020-08-17 at 12 22 36 PM](https://user-images.githubusercontent.com/9526468/90380174-6ac7b800-e084-11ea-9277-ff9617cefdcd.png)

Not focused:
![Screen Shot 2020-08-17 at 12 22 24 PM](https://user-images.githubusercontent.com/9526468/90380164-67343100-e084-11ea-8526-7d37010b7e07.png)


But here is one problem - at the moment `Input` control has inconsistent display flow. On initialization step it shows the `props.value` but then if you input any string it writes a new value directly into `input` control and shows that value. In this case the `Input` will not reflect on any changes of the `props.value`.  
@morethanfire  I see that initially you tried to use internal state to store the changed string, why did you give up this idea? Does it make sense to go back to this option?