### PR TITLE
[dev] [No Bug/PBI] Stop Propagation on click of <DropdownButton />

### DIFF
--- a/src/inputs/dropdownButton/dropdownButton.jsx
+++ b/src/inputs/dropdownButton/dropdownButton.jsx
@@ -93,7 +93,8 @@ function DropdownButton(props) {
         return dropdownButtonRef.current;
     }
 
-    function onMenuToggle() {
+    function onMenuToggle(event) {
+        event.stopPropagation();
         setIsOpen(!isMenuOpen);
     }
 


### PR DESCRIPTION
When `<DropdownButton />` is clicked to toggle open the menu, stop propagation of the click event.

This is needed for a use case in Rules 2.0 feature work; see for example: https://www.sketch.com/s/b7836185-bf30-4024-bedb-530069a04c05/a/lMVaMv.  In those cases, the `...` is a `<DropdownButton />` action menu, but the "panel" that it resides in is also clickable for selection.  When the dropdown menu is activated, we don't want to also click the whole panel to select it.