### PR TITLE
[dev] No PBI - Enhancing Person Panel Select Record button for Client's Add Person V2

### DIFF
--- a/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
@@ -255,4 +255,29 @@ describe('<PersonPanelDetails />', () => {
         expect(props.viewRecordButtonProps.onClick).toHaveBeenCalledTimes(1);
         expect(props.viewRecordButtonProps.onKeyDown).toHaveBeenCalledTimes(1);
     });
+
+
+    it('Should disable select record button and apply a custom label', () => {
+        const testCaseProps = {
+            ...props,
+            selectButtonProps: {
+                ...props.selectButtonProps,
+                disable: true,
+                label: 'My Custom Label'
+            }
+        }
+
+        const wrapper = mountWithTheme(
+            <PersonPanelDetails {...testCaseProps}/>,
+        );
+
+        const selectRecordButton = wrapper.find('.block_name--select').at(0);
+
+        expect(selectRecordButton.find('button').prop('disabled')).toBe(true);
+
+        expect(
+            selectRecordButton
+                .find('.button-inner-container').prop('children')
+        ).toBe('My Custom Label');
+    });
 });

--- a/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
@@ -257,7 +257,7 @@ describe('<PersonPanelDetails />', () => {
     });
 
 
-    it('Should disable select record button and apply a custom label', () => {
+    it('Should disable select record button and apply a custom label using \'selectButtonProps\'', () => {
         const testCaseProps = {
             ...props,
             selectButtonProps: {
@@ -274,7 +274,6 @@ describe('<PersonPanelDetails />', () => {
         const selectRecordButton = wrapper.find('.block_name--select').at(0);
 
         expect(selectRecordButton.find('button').prop('disabled')).toBe(true);
-
         expect(
             selectRecordButton
                 .find('.button-inner-container').prop('children')

--- a/src/dataDisplay/personPanel/personPanelDetails.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetails.jsx
@@ -895,8 +895,8 @@ function PersonPanelDetails(props) {
                         >
                             {!isEmpty(selectButtonProps) && (
                                 <PersonPanelDetailsActionButton
-                                    // eslint-disable-next-line react/jsx-props-no-spreading
                                     label="Select"
+                                    // eslint-disable-next-line react/jsx-props-no-spreading
                                     {...selectButtonProps}
                                 />
                             )}

--- a/src/dataDisplay/personPanel/personPanelDetails.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetails.jsx
@@ -162,7 +162,9 @@ const propTypes = {
      */
     selectButtonProps: PropTypes.shape({
         className: PropTypes.string,
+        disable: PropTypes.bool,
         id: PropTypes.string,
+        label: PropTypes.string,
         onClick: PropTypes.func,
         onKeyDown: PropTypes.func,
         onPromptCancelClick: PropTypes.func,
@@ -194,7 +196,10 @@ const defaultProps = {
     isExpanded: false,
     isMobile: false,
     otherDataGroups: null,
-    selectButtonProps: {},
+    selectButtonProps: {
+        label: 'Select',
+        disable: false,
+    },
     viewRecordButtonProps: {},
 };
 
@@ -891,8 +896,8 @@ function PersonPanelDetails(props) {
                             {!isEmpty(selectButtonProps) && (
                                 <PersonPanelDetailsActionButton
                                     // eslint-disable-next-line react/jsx-props-no-spreading
-                                    {...selectButtonProps}
                                     label="Select"
+                                    {...selectButtonProps}
                                 />
                             )}
 

--- a/src/dataDisplay/personPanel/personPanelDetailsActionButton.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetailsActionButton.jsx
@@ -11,6 +11,7 @@ import { BEM_PERSON_PANEL_DETAILS_ACTION_BUTTON } from '../../global/constants';
 
 const propTypes = {
     className: PropTypes.string,
+    disable: PropTypes.bool,
     id: PropTypes.string,
     label: PropTypes.string,
     onClick: PropTypes.func,
@@ -25,6 +26,7 @@ const propTypes = {
 
 const defaultProps = {
     className: null,
+    disable: false;
     id: null,
     onClick: null,
     onKeyDown: null,
@@ -45,6 +47,7 @@ const useStyles = makeStyles({
 function PersonPanelDetailsActionButton(props) {
     const {
         className,
+        disable,
         id,
         label,
         onClick: onClickProp,
@@ -98,6 +101,7 @@ function PersonPanelDetailsActionButton(props) {
                 classes.button,
                 className,
             )}
+            disable={disable}
             id={id}
             outlined={outlined}
             onClick={onClick}
@@ -108,7 +112,7 @@ function PersonPanelDetailsActionButton(props) {
         </Button>
     );
 
-    if (prompt) {
+    if (prompt && !disable) {
         return (
             <Prompt
                 className={ClassNames(

--- a/src/dataDisplay/personPanel/personPanelDetailsActionButton.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetailsActionButton.jsx
@@ -26,7 +26,7 @@ const propTypes = {
 
 const defaultProps = {
     className: null,
-    disable: false;
+    disable: false,
     id: null,
     onClick: null,
     onKeyDown: null,


### PR DESCRIPTION
This PR contains changes for `<PersonPanelDetailsActionButton />`:

- It allows to disable the button.
- It allows to set a custom label.

We're using this capabilities in the client for validations on Serving Opps volunteer/schedule rosters disabling the select record button with a label "Already Scheduled" or "Already on Roster".

Here's the [design](https://www.sketch.com/s/a38825f5-c93b-46e1-a4e9-6adb92897d38/a/m1bRo38).