### PR TITLE
[dev] AB#48476: [G.1.1] - Ability to quick create multiple serving opportunities (one-time event)

### DIFF
--- a/src/dataDisplay/dataCards/dataCards.jsx
+++ b/src/dataDisplay/dataCards/dataCards.jsx
@@ -2,6 +2,9 @@ import _ from 'lodash';
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import DataCard from './dataCard';
 
 const propTypes = {
@@ -9,6 +12,10 @@ const propTypes = {
     className: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     moduleType: PropTypes.oneOf(['drawer', 'page']).isRequired,
     style: PropTypes.shape({}),
 };
@@ -16,6 +23,7 @@ const propTypes = {
 const defaultProps = {
     cardProps: undefined,
     className: undefined,
+    dataTestId: `${UI_CLASS_NAME}-data_cards`,
     style: {},
 };
 
@@ -25,14 +33,17 @@ function DataCards(props) {
         className,
         columns,
         data,
+        dataTestId,
         moduleType,
         style,
     } = props;
+
     const containerClasses = ClassNames('ui', `${moduleType}--data_cards`, className);
 
     return (
         <div
             className={containerClasses}
+            data-testid={dataTestId}
             style={style}
         >
             {_.map(data, (d, index) => {

--- a/src/dataDisplay/dataGrid/dataGrid.jsx
+++ b/src/dataDisplay/dataGrid/dataGrid.jsx
@@ -1,7 +1,10 @@
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
-import { BEM_DATA_GRID } from '../../global/constants';
+import {
+    BEM_DATA_GRID,
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import { SORTABLE_PROP_TYPES } from './dataGridConstants';
 import DataGridTable from './dataGridTable';
 import makeStyles from '../../styles/makeStyles';
@@ -20,6 +23,10 @@ const propTypes = {
             PropTypes.shape({}),
         ]),
     ).isRequired,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     fontSize: PropTypes.string,
     id: PropTypes.string.isRequired,
     minWidth: PropTypes.number,
@@ -45,6 +52,7 @@ const defaultProps = {
     bleed: true,
     classes: null,
     className: undefined,
+    dataTestId: `${UI_CLASS_NAME}-${BEM_DATA_GRID}`,
     fontSize: undefined,
     minWidth: 800,
     moduleType: null,
@@ -108,6 +116,7 @@ function DataGrid(props) {
         className,
         columns,
         data,
+        dataTestId,
         fontSize,
         id,
         minWidth: minWidthProp,
@@ -157,6 +166,7 @@ function DataGrid(props) {
     return (
         <div
             className={rootClasses}
+            data-testid={dataTestId}
             style={style}
         >
             <DataGridTable

--- a/src/dataDisplay/dataGroups/dataGroups.jsx
+++ b/src/dataDisplay/dataGroups/dataGroups.jsx
@@ -7,19 +7,29 @@ import {
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    groupPropTypes,
+} from './dataGroupsPropTypes';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import DataGroupsColumn from './dataGroupsColumn';
-import { groupPropTypes } from './dataGroupsPropTypes';
 
 const propTypes = {
     className: PropTypes.string,
     columns: PropTypes.arrayOf(groupPropTypes).isRequired,
     data: PropTypes.shape({}).isRequired,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     moduleType: PropTypes.string.isRequired,
     style: PropTypes.shape({}),
 };
 
 const defaultProps = {
     className: undefined,
+    dataTestId: `${UI_CLASS_NAME}-data_groups`,
     style: {},
 };
 
@@ -101,9 +111,11 @@ class DataGroups extends React.PureComponent {
         const {
             className,
             data,
+            dataTestId,
             moduleType,
             style,
         } = this.props;
+
         const { columns } = this.state;
         const bemClassName = `${moduleType}--data_groups`;
         const rootClasses = ClassNames('ui', bemClassName, className);
@@ -111,6 +123,7 @@ class DataGroups extends React.PureComponent {
         return (
             <div
                 className={rootClasses}
+                dataTestId={dataTestId}
                 ref={(ref) => { this.dataGroups = ref; }}
                 style={style}
             >

--- a/src/surfaces/drawer/drawerActionBar.jsx
+++ b/src/surfaces/drawer/drawerActionBar.jsx
@@ -1,12 +1,19 @@
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import ActionBar from '../../surfaces/actionBar'; // eslint-disable-line import/no-cycle
 
 const propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.shape({})),
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     id: PropTypes.string,
     style: PropTypes.shape({}),
 };
@@ -15,6 +22,7 @@ const defaultProps = {
     children: undefined,
     className: undefined,
     columns: undefined,
+    dataTestId: `${UI_CLASS_NAME}-drawer_action_bar`,
     id: undefined,
     style: {},
 };
@@ -58,13 +66,16 @@ class DrawerActionBar extends React.PureComponent {
             children,
             className,
             columns,
+            dataTestId,
             id,
             style,
         } = this.props;
+
         const containerClasses = ClassNames('drawer--action_bar', className);
 
         return (
             <div
+                data-testid={dataTestId}
                 ref={(ref) => { this.drawerActionBarRef = ref; }}
             >
                 <ActionBar

--- a/src/surfaces/drawer/drawerContainer.jsx
+++ b/src/surfaces/drawer/drawerContainer.jsx
@@ -1,10 +1,17 @@
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 
 const propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     id: PropTypes.string,
     style: PropTypes.shape({}),
 };
@@ -12,6 +19,7 @@ const propTypes = {
 const defaultProps = {
     children: null,
     className: null,
+    dataTestId: `${UI_CLASS_NAME}-drawer_container`,
     id: null,
     style: null,
 };
@@ -20,6 +28,7 @@ function DrawerContainer(props) {
     const {
         children,
         className,
+        dataTestId,
         id,
         style,
     } = props;
@@ -29,6 +38,7 @@ function DrawerContainer(props) {
     return (
         <div
             className={rootClasses}
+            data-testid={dataTestId}
             id={id}
             style={style}
         >

--- a/src/surfaces/drawer/drawerContent.jsx
+++ b/src/surfaces/drawer/drawerContent.jsx
@@ -1,6 +1,9 @@
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import makeStyles from '../../styles/makeStyles';
 import Utils from '../../utils/utils';
 
@@ -8,6 +11,10 @@ const propTypes = {
     as: PropTypes.oneOf(['div', 'header', 'main', 'section']),
     children: PropTypes.node,
     className: PropTypes.string,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     id: PropTypes.string,
     isFiltersRailOpen: PropTypes.bool,
     scrollable: PropTypes.bool,
@@ -18,6 +25,7 @@ const defaultProps = {
     as: 'section',
     children: null,
     className: null,
+    dataTestId: `${UI_CLASS_NAME}-drawer_content`,
     id: null,
     isFiltersRailOpen: false,
     scrollable: false,
@@ -59,6 +67,7 @@ function DrawerContent(props) {
         as,
         children,
         className,
+        dataTestId,
         id,
         isFiltersRailOpen,
         scrollable,
@@ -86,6 +95,7 @@ function DrawerContent(props) {
     return (
         <ElementType
             className={rootClasses}
+            data-testid={dataTestId}
             id={id}
             style={style}
         >

--- a/src/surfaces/drawer/drawerDataCards.jsx
+++ b/src/surfaces/drawer/drawerDataCards.jsx
@@ -1,11 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import DataCards from '../../dataDisplay/dataCards';
 
 const propTypes = {
     cardProps: PropTypes.func,
     className: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     style: PropTypes.shape({}),
 };
@@ -13,6 +20,7 @@ const propTypes = {
 const defaultProps = {
     cardProps: undefined,
     className: undefined,
+    dataTestId: `${UI_CLASS_NAME}-drawer_data_cards`,
     style: {},
 };
 
@@ -22,6 +30,7 @@ function DrawerDataCards(props) {
         className,
         columns,
         data,
+        dataTestId,
         style,
     } = props;
 
@@ -31,6 +40,7 @@ function DrawerDataCards(props) {
             className={className}
             columns={columns}
             data={data}
+            data-testid={dataTestId}
             moduleType="drawer"
             style={style}
         />

--- a/src/surfaces/drawer/drawerDataGrid.jsx
+++ b/src/surfaces/drawer/drawerDataGrid.jsx
@@ -1,20 +1,33 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import DataGrid from '../../dataDisplay/dataGrid';
 
 const propTypes = {
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     id: PropTypes.string,
 };
 
 const defaultProps = {
+    dataTestId: `${UI_CLASS_NAME}-drawer_data_grid`,
     id: 'drawer',
 };
 
 function DrawerDataGrid(props) {
+    const {
+        dataTestId,
+    } = props;
+
     return (
         <DataGrid
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
+            data-testid={dataTestId}
             moduleType="drawer"
         />
     );

--- a/src/surfaces/drawer/drawerDataGroups.jsx
+++ b/src/surfaces/drawer/drawerDataGroups.jsx
@@ -1,19 +1,27 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import DataGroups from '../../dataDisplay/dataGroups';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import { groupPropTypes } from '../../dataDisplay/dataGroups/dataGroupsPropTypes';
+import DataGroups from '../../dataDisplay/dataGroups';
 
 const propTypes = {
     bleed: PropTypes.bool,
     className: PropTypes.string,
     columns: PropTypes.arrayOf(groupPropTypes).isRequired,
     data: PropTypes.shape({}).isRequired,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     style: PropTypes.shape({}),
 };
 
 const defaultProps = {
     bleed: false,
     className: '',
+    dataTestId: `${UI_CLASS_NAME}-drawer_data_groups`,
     style: {},
 };
 
@@ -23,6 +31,7 @@ function DrawerDataGroups(props) {
         className,
         columns,
         data,
+        dataTestId,
         style,
     } = props;
 
@@ -32,6 +41,7 @@ function DrawerDataGroups(props) {
             className={className}
             columns={columns}
             data={data}
+            data-testid={dataTestId}
             moduleType="drawer"
             style={style}
         />

--- a/src/surfaces/drawer/drawerDetailsWindow.jsx
+++ b/src/surfaces/drawer/drawerDetailsWindow.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import { columnPropTypesShape } from '../detailsWindow/detailsWindowPropTypes';
 import DetailsWindow from '../detailsWindow';
 
@@ -10,6 +13,10 @@ const propTypes = {
     columnProps: PropTypes.shape({}),
     columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     data: PropTypes.shape({}).isRequired,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     expandableColumns: PropTypes.arrayOf(columnPropTypesShape),
     style: PropTypes.shape({}),
 };
@@ -19,6 +26,7 @@ const defaultProps = {
     className: undefined,
     color: undefined,
     columnProps: undefined,
+    dataTestId: `${UI_CLASS_NAME}-drawer_details_window`,
     expandableColumns: undefined,
     style: {},
 };
@@ -32,6 +40,7 @@ const DrawerDetailsWindow = React.forwardRef(function DrawerDetailsWindow(props,
         columnProps,
         columns,
         data,
+        dataTestId,
         expandableColumns,
         style,
     } = props;
@@ -44,6 +53,7 @@ const DrawerDetailsWindow = React.forwardRef(function DrawerDetailsWindow(props,
             columnProps={columnProps}
             columns={columns}
             data={data}
+            data-testid={dataTestId}
             expandableColumns={expandableColumns}
             forwardedRef={ref}
             style={style}

--- a/src/surfaces/drawer/drawerFiltersDrawer.jsx
+++ b/src/surfaces/drawer/drawerFiltersDrawer.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import FiltersDrawer from '../../surfaces/filtersDrawer'; // eslint-disable-line import/no-cycle
 
 const propTypes = {
@@ -9,6 +12,10 @@ const propTypes = {
     ]),
     children: PropTypes.node,
     className: PropTypes.string,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     id: PropTypes.string,
     isDirty: PropTypes.bool.isRequired,
     isFiltering: PropTypes.bool.isRequired,
@@ -24,6 +31,7 @@ const defaultProps = {
     breakpointDown: undefined,
     children: undefined,
     className: undefined,
+    dataTestId: `${UI_CLASS_NAME}-drawer_filters_drawer`,
     id: undefined,
     rows: undefined,
     style: {},
@@ -34,6 +42,7 @@ function DrawerFiltersDrawer(props) {
         breakpointDown,
         children,
         className,
+        dataTestId,
         id,
         isDirty,
         isFiltering,
@@ -49,6 +58,7 @@ function DrawerFiltersDrawer(props) {
         <FiltersDrawer
             breakpointDown={breakpointDown}
             className={className}
+            data-testid={dataTestId}
             id={id}
             isDirty={isDirty}
             isFiltering={isFiltering}

--- a/src/surfaces/drawer/drawerFiltersRail.jsx
+++ b/src/surfaces/drawer/drawerFiltersRail.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import FiltersRail from '../filtersRail';
 
 const propTypes = {
@@ -9,6 +12,10 @@ const propTypes = {
     ]),
     children: PropTypes.node,
     className: PropTypes.string,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     id: PropTypes.string,
     isOpen: PropTypes.bool,
     isScrollable: PropTypes.bool,
@@ -19,6 +26,7 @@ const defaultProps = {
     breakpointUp: undefined,
     children: undefined,
     className: undefined,
+    dataTestId: `${UI_CLASS_NAME}-drawer_filters_rail`,
     id: undefined,
     isOpen: undefined,
     isScrollable: false,
@@ -30,6 +38,7 @@ function DrawerFiltersRail(props) {
         breakpointUp,
         children,
         className,
+        dataTestId,
         id,
         isOpen,
         isScrollable,
@@ -40,6 +49,7 @@ function DrawerFiltersRail(props) {
         <FiltersRail
             breakpointUp={breakpointUp}
             className={className}
+            data-testid={dataTestId}
             id={id}
             isOpen={isOpen}
             isScrollable={isScrollable}

--- a/src/surfaces/drawer/drawerNavigation.jsx
+++ b/src/surfaces/drawer/drawerNavigation.jsx
@@ -2,6 +2,9 @@ import _ from 'lodash';
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import SubNavigation from '../../navigation/subNavigation/subNavigation';
 
 const hasClassName = 'drawer-has_navigation';
@@ -9,12 +12,17 @@ const hasClassName = 'drawer-has_navigation';
 const propTypes = {
     className: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     selectedColumnIndex: PropTypes.number,
     style: PropTypes.shape({}),
 };
 
 const defaultProps = {
     className: undefined,
+    dataTestId: `${UI_CLASS_NAME}-drawer_navigation`,
     selectedColumnIndex: 0,
     style: {},
 };
@@ -32,14 +40,17 @@ class DrawerNavigation extends React.PureComponent {
         const {
             columns,
             className,
+            dataTestId,
             selectedColumnIndex,
             style,
         } = this.props;
+
         const containerClasses = ClassNames('ui', 'drawer--navigation', className);
 
         return (
             <div
                 className={containerClasses}
+                data-testid={dataTestId}
                 ref={(ref) => { this.drawerNavigationRef = ref; }}
                 style={style}
             >

--- a/src/surfaces/drawer/drawerTitleBar.jsx
+++ b/src/surfaces/drawer/drawerTitleBar.jsx
@@ -2,12 +2,19 @@ import _ from 'lodash';
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import Header from '../../dataDisplay/header';
 
 const propTypes = {
     className: PropTypes.string,
     closeButton: PropTypes.shape({}),
     closeButtonStyle: PropTypes.shape({}),
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     style: PropTypes.shape({}),
     title: PropTypes.oneOfType([
         PropTypes.shape({}),
@@ -20,6 +27,7 @@ const defaultProps = {
     className: undefined,
     closeButton: undefined,
     closeButtonStyle: {},
+    dataTestId: `${UI_CLASS_NAME}-drawer_title_bar`,
     style: {},
     title: undefined,
     titleStyle: {},
@@ -64,15 +72,18 @@ class DrawerTitleBar extends React.PureComponent {
             className,
             closeButton,
             closeButtonStyle,
+            dataTestId,
             style,
             title,
             titleStyle,
         } = this.props;
+
         const containerClasses = ClassNames('ui', 'drawer--title_bar', className);
 
         return (
             <header
                 className={containerClasses}
+                data-testid={dataTestId}
                 ref={(ref) => { this.drawerTitleBarRef = ref; }}
                 style={style}
             >

--- a/src/surfaces/drawer/drawerWing.jsx
+++ b/src/surfaces/drawer/drawerWing.jsx
@@ -2,6 +2,9 @@ import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ScrollBar from 'react-custom-scrollbars';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import domUtils from '../../utils/domUtils';
 
 const propTypes = {
@@ -9,6 +12,10 @@ const propTypes = {
     className: PropTypes.string,
     color: PropTypes.oneOf(['blue', 'grey', 'white']),
     isOpen: PropTypes.bool,
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
     position: PropTypes.oneOf(['left', 'right']),
     style: PropTypes.shape({}),
     width: PropTypes.string,
@@ -18,6 +25,7 @@ const defaultProps = {
     children: undefined,
     className: undefined,
     color: 'white',
+    dataTestId: `${UI_CLASS_NAME}-drawer_wing`,
     isOpen: undefined,
     position: 'right',
     style: {},
@@ -105,10 +113,12 @@ class DrawerWing extends React.PureComponent {
             children,
             className,
             color,
+            dataTestId,
             position,
             style,
             width,
         } = this.props;
+
         const { isOpen } = this.state;
 
         if (!isOpen) {
@@ -116,6 +126,7 @@ class DrawerWing extends React.PureComponent {
         }
 
         const isPositionLeft = position === 'left';
+
         const containerClasses = ClassNames('ui', 'drawer--wing', className, {
             'color-blue': color === 'blue',
             'color-grey': color === 'grey',
@@ -126,6 +137,7 @@ class DrawerWing extends React.PureComponent {
         return (
             <div
                 className={containerClasses}
+                data-testid={dataTestId}
                 ref={(ref) => { this.drawerWingRef = ref; }}
                 style={style}
             >


### PR DESCRIPTION
Added some `dataTestId` props to the drawer components.