### PR TITLE
[dev] AB#48476: [G.1.1] - Ability to quick create multiple serving opportunities (one-time event)

### DIFF
--- a/docs/src/inputs/dropdownDeprecated/dropdownDeprecated.jsx
+++ b/docs/src/inputs/dropdownDeprecated/dropdownDeprecated.jsx
@@ -1285,94 +1285,90 @@ class ModulesDropdown extends React.Component {
                         </Header>
 
                         <Grid>
-                            <Grid.Row stackable>
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="alert" collapseMenuOnChange text="Alert" style={{ maxWidth: '200px', width: '100%' }}>
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="alert" collapseMenuOnChange text="Alert" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="alternate" collapseMenuOnChange text="Alternate" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="disable" collapseMenuOnChange text="Disable" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="light" collapseMenuOnChange text="Light" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="outline" collapseMenuOnChange text="Outline" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="primary" collapseMenuOnChange text="Primary" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="secondary" collapseMenuOnChange text="Secondary" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="success" collapseMenuOnChange text="Success" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <Dropdown button buttonColor="warning" collapseMenuOnChange text="Warning" style={{ maxWidth: '200px', width: '100%' }}>
+                                    <Dropdown.Item label="Option 1" />
+                                    <Dropdown.Item label="Option 2" />
+                                </Dropdown>
+                            </Grid.Column>
+
+                            <Grid.Column width={6} tablet={4} laptop={2}>
+                                <div style={{ flex: '0 0 auto' }}>
+                                    <Dropdown
+                                        button
+                                        buttonColor="transparent"
+                                        buttonCompact
+                                        collapseMenuOnChange
+                                        iconColor="static"
+                                        iconTitle={'Transparent icon button dropdown'}
+                                        iconType="ellipsis-h"
+                                        onChange={() => { }}
+                                        style={{ margin: 0 }}
+                                    >
                                         <Dropdown.Item label="Option 1" />
                                         <Dropdown.Item label="Option 2" />
                                     </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="alternate" collapseMenuOnChange text="Alternate" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="disable" collapseMenuOnChange text="Disable" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="light" collapseMenuOnChange text="Light" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="outline" collapseMenuOnChange text="Outline" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="primary" collapseMenuOnChange text="Primary" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-                            </Grid.Row>
-
-                            <Grid.Row stackable>
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="secondary" collapseMenuOnChange text="Secondary" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="success" collapseMenuOnChange text="Success" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <Dropdown button buttonColor="warning" collapseMenuOnChange text="Warning" style={{ maxWidth: '200px', width: '100%' }}>
-                                        <Dropdown.Item label="Option 1" />
-                                        <Dropdown.Item label="Option 2" />
-                                    </Dropdown>
-                                </Grid.Column>
-
-                                <Grid.Column width={6} tablet={4} laptop={2}>
-                                    <div style={{ flex: '0 0 auto' }}>
-                                        <Dropdown
-                                            button
-                                            buttonColor="transparent"
-                                            buttonCompact
-                                            collapseMenuOnChange
-                                            iconColor="static"
-                                            iconTitle={'Transparent icon button dropdown'}
-                                            iconType="ellipsis-h"
-                                            onChange={() => { }}
-                                            style={{ margin: 0 }}
-                                        >
-                                            <Dropdown.Item label="Option 1" />
-                                            <Dropdown.Item label="Option 2" />
-                                        </Dropdown>
-                                        <div style={{ display: 'inline-flex' }}>
-                                            {'(Transparent)'}
-                                        </div>
+                                    <div style={{ display: 'inline-flex' }}>
+                                        {'(Transparent)'}
                                     </div>
-                                </Grid.Column>
-                            </Grid.Row>
+                                </div>
+                            </Grid.Column>
                         </Grid>
 
                         <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>

--- a/docs/src/inputs/select/constants.js
+++ b/docs/src/inputs/select/constants.js
@@ -15,4 +15,68 @@ export const options = [
         label: 'Option 4',
         value: 4,
     },
+    {
+        label: 'Option 5',
+        value: 5,
+    },
+    {
+        label: 'Option 6',
+        value: 6,
+    },
+    {
+        label: 'Option 7',
+        value: 7,
+    },
+    {
+        label: 'Option 8',
+        value: 8,
+    },
+    {
+        label: 'Option 9',
+        value: 9,
+    },
+    {
+        label: 'Option 10',
+        value: 10,
+    },
+    {
+        label: 'Option 11',
+        value: 11,
+    },
+    {
+        label: 'Option 12',
+        value: 12,
+    },
+    {
+        label: 'Option 13',
+        value: 13,
+    },
+    {
+        label: 'Option 14',
+        value: 14,
+    },
+    {
+        label: 'Option 15',
+        value: 15,
+    },
+    {
+        label: 'Option 16',
+        value: 16,
+    },
+    {
+        label: 'Option 17',
+        value: 17,
+    },
+    {
+        label: 'Option 18',
+        value: 18,
+    },
+    {
+        label: 'Option 19',
+        value: 19,
+    },
+    {
+        label: 'Option 20',
+        value: 20,
+    },
 ];

--- a/docs/src/inputs/select/examples/exampleDefaultSelect.jsx
+++ b/docs/src/inputs/select/examples/exampleDefaultSelect.jsx
@@ -7,20 +7,16 @@ import { options } from '../constants';
 
 function ExampleDefaultSelect() {
     const [selectedValue, setOption] = useState({});
-    function onSelect(selectedOption) {
-        setOption(selectedOption);
-    }
 
     return (
-        <div>
-            <Select
-                id="block--select_id"
-                options={options}
-                onChange={onSelect}
-                placeholder="Select"
-                value={!isEmpty(selectedValue) ? selectedValue : null}
-            />
-        </div>
+        <Select
+            id="block--select_id"
+            onChange={setOption}
+            options={options}
+            placeholder="Select"
+            tabIndex={0}
+            value={!isEmpty(selectedValue) ? selectedValue : null}
+        />
     );
 }
 

--- a/src/inputs/select/select.jsx
+++ b/src/inputs/select/select.jsx
@@ -769,11 +769,11 @@ const Select = React.forwardRef(function Select(props, ref) {
     const innerMenuRef = useRef();
     const menuScrollBarRef = useRef();
     const focusedOptionRef = useRef();
-    const [foo, setFoo] = React.useState(false);
+    const [scrollToFocusedOption, setScrollToFocusedOption] = React.useState(false);
 
     React.useEffect(() => {
         if (
-            foo &&
+            scrollToFocusedOption &&
             focusedOptionRef && focusedOptionRef.current &&
             innerMenuRef && innerMenuRef.current &&
             menuScrollBarRef && menuScrollBarRef.current
@@ -791,9 +791,9 @@ const Select = React.forwardRef(function Select(props, ref) {
                 menuScrollBarRef.current.scrollTop(focusedDOM.offsetTop);
             }
 
-            setFoo(false);
+            setScrollToFocusedOption(false);
         }
-    }, [foo]);
+    }, [scrollToFocusedOption]);
 
     const onChange = (selectedOption) => {
         if (isFunction(onChangeProp)) {
@@ -880,7 +880,7 @@ const Select = React.forwardRef(function Select(props, ref) {
         switch (event.keyCode) {
             case 38: // up
             case 40: // down
-                setFoo(true);
+                setScrollToFocusedOption(true);
 
                 break;
             default:


### PR DESCRIPTION
In this PR:
- Fixed the dropdown deprecated docs page
- Added a bunch of new simple Select options for our examples.
- Removed `autoScrollSelection`. No need for this. it should have been doing this all along without an extra prop. It now scrolls to the selected option on open by default.
- Fixed disabled option styling.
- Fixed scrolling to focused option, sense our component is using its own menu scroller.
- Added and updated option props