### PR TITLE
[dev] PBI AB#25925 [V.2] - Ability to sort & filter entries for a connection form - Add Prop to optionally Suppress Time Zone Select in TimePicker

### DIFF
--- a/docs/src/app/navigationConstants.js
+++ b/docs/src/app/navigationConstants.js
@@ -362,6 +362,18 @@ export const navigationItems = [
                     {
                         component: 'timePicker',
                         label: 'Time Picker',
+                        levelFour: [
+                            {
+                                component: 'devSandbox/index.js',
+                                label: 'Dev Sandbox',
+                                path: 'dev-sandbox',
+                            },
+                            {
+                                component: 'api/index.js',
+                                label: 'API',
+                                path: 'api',
+                            },
+                        ],
                         path: 'time-picker',
                     },
                 ],

--- a/docs/src/global/componentVersionIdentifier.jsx
+++ b/docs/src/global/componentVersionIdentifier.jsx
@@ -1,6 +1,7 @@
 import {
     filter,
     get,
+    isEmpty,
     map,
     startCase,
 } from 'lodash';
@@ -60,11 +61,15 @@ function ComponentVersionIdentifier(props) {
                             >
                                 {`${startCase(key)}: `}
 
-                                <a
-                                    href={v}
-                                >
-                                    {v}
-                                </a>
+                                {!isEmpty(v) && v !== 'N/A' ? (
+                                    <a
+                                        href={v}
+                                    >
+                                        {v}
+                                    </a>
+                                ) : (
+                                    <span>{v}</span>
+                                )}
                             </div>
                         );
                     }

--- a/docs/src/inputs/select/devSandbox/devSandbox.jsx
+++ b/docs/src/inputs/select/devSandbox/devSandbox.jsx
@@ -133,7 +133,8 @@ function ElementsSelect() {
                         anchorLink="select-creatable-advanced"
                         variant="h2"
                     >
-                        Creatable Advanced Select (Option Component, Value Component & Prompt Text Creator )
+                        Creatable Advanced Select
+                        (Option Component, Value Component & Prompt Text Creator )
                     </Heading>
 
                     <Example

--- a/docs/src/inputs/timePicker/api/api.jsx
+++ b/docs/src/inputs/timePicker/api/api.jsx
@@ -1,0 +1,29 @@
+import {
+    camelCase,
+} from 'lodash';
+import React from 'react';
+import ComponentApi from '../../../global/componentApi';
+import Main from '../../../global/main';
+/* eslint-disable import/no-named-default, import/extensions */
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/timePicker/timePicker';
+/* eslint-enable import/no-named-default, import/extensions */
+
+function DocsApi() {
+    const {
+        displayName,
+    } = rootDoc;
+
+    return (
+        <Main page={camelCase(displayName)}>
+            <Main.Content>
+                <ComponentApi
+                    docs={[
+                        rootDoc,
+                    ]}
+                />
+            </Main.Content>
+        </Main>
+    );
+}
+
+export default DocsApi;

--- a/docs/src/inputs/timePicker/api/index.js
+++ b/docs/src/inputs/timePicker/api/index.js
@@ -1,0 +1,1 @@
+export { default } from './api';

--- a/docs/src/inputs/timePicker/constants.js
+++ b/docs/src/inputs/timePicker/constants.js
@@ -1,0 +1,434 @@
+export const CUSTOM_TIME_ZONE_SELECT_OPTIONS = [
+    {
+        value: 'Etc/GMT+12',
+        label: '(UTC-12:00) International Date Line West',
+    },
+    {
+        value: 'Etc/GMT+11',
+        label: '(UTC-11:00) Coordinated Universal Time-11',
+    },
+    {
+        value: 'Pacific/Honolulu',
+        label: '(UTC-10:00) Hawaii',
+    },
+    {
+        value: 'America/Anchorage',
+        label: '(UTC-09:00) Alaska',
+    },
+    {
+        value: 'America/Tijuana',
+        label: '(UTC-08:00) Baja California',
+    },
+    {
+        value: 'America/Los_Angeles',
+        label: '(UTC-08:00) Pacific Time (US & Canada)',
+    },
+    {
+        value: 'America/Phoenix',
+        label: '(UTC-07:00) Arizona',
+    },
+    {
+        value: 'America/Chihuahua',
+        label: '(UTC-07:00) Chihuahua, La Paz, Mazatlan',
+    },
+    {
+        value: 'America/Denver',
+        label: '(UTC-07:00) Mountain Time (US & Canada)',
+    },
+    {
+        value: 'America/Guatemala',
+        label: '(UTC-06:00) Central America',
+    },
+    {
+        value: 'America/Chicago',
+        label: '(UTC-06:00) Central Time (US & Canada)',
+    },
+    {
+        value: 'America/Mexico_City',
+        label: '(UTC-06:00) Guadalajara, Mexico City, Monterrey',
+    },
+    {
+        value: 'America/Regina',
+        label: '(UTC-06:00) Saskatchewan',
+    },
+    {
+        value: 'America/Bogota',
+        label: '(UTC-05:00) Bogota, Lima, Quito, Rio Branco',
+    },
+    {
+        value: 'America/Cancun',
+        label: '(UTC-05:00) Chetumal',
+    },
+    {
+        value: 'America/New_York',
+        label: '(UTC-05:00) Eastern Time (US & Canada)',
+    },
+    {
+        value: 'America/Indianapolis',
+        label: '(UTC-05:00) Indiana (East)',
+    },
+    {
+        value: 'America/Caracas',
+        label: '(UTC-04:30) Caracas',
+    },
+    {
+        value: 'America/Asuncion',
+        label: '(UTC-04:00) Asuncion',
+    },
+    {
+        value: 'America/Halifax',
+        label: '(UTC-04:00) Atlantic Time (Canada)',
+    },
+    {
+        value: 'America/Cuiaba',
+        label: '(UTC-04:00) Cuiaba',
+    },
+    {
+        value: 'America/La_Paz',
+        label: '(UTC-04:00) Georgetown, La Paz, Manaus, San Juan',
+    },
+    {
+        value: 'America/St_Johns',
+        label: '(UTC-03:30) Newfoundland',
+    },
+    {
+        value: 'America/Sao_Paulo',
+        label: '(UTC-03:00) Brasilia',
+    },
+    {
+        value: 'America/Argentina/Buenos_Aires',
+        label: '(UTC-03:00) Buenos Aires',
+    },
+    {
+        value: 'America/Cayenne',
+        label: '(UTC-03:00) Cayenne, Fortaleza',
+    },
+    {
+        value: 'America/Godthab',
+        label: '(UTC-03:00) Greenland',
+    },
+    {
+        value: 'America/Montevideo',
+        label: '(UTC-03:00) Montevideo',
+    },
+    {
+        value: 'America/Bahia',
+        label: '(UTC-03:00) Salvador',
+    },
+    {
+        value: 'America/Santiago',
+        label: '(UTC-03:00) Santiago',
+    },
+    {
+        value: 'Etc/GMT+2',
+        label: '(UTC-02:00) Coordinated Universal Time-02',
+    },
+    {
+        value: 'Atlantic/Azores',
+        label: '(UTC-01:00) Azores',
+    },
+    {
+        value: 'Atlantic/Cape_Verde',
+        label: '(UTC-01:00) Cabo Verde Is.',
+    },
+    {
+        value: 'Europe/London',
+        label: '(UTC) Dublin, Edinburgh, Lisbon, London',
+    },
+    {
+        value: 'Atlantic/Reykjavik',
+        label: '(UTC) Monrovia, Reykjavik',
+    },
+    {
+        value: 'Etc/GMT',
+        label: 'UTC',
+    },
+    {
+        value: 'Africa/Casablanca',
+        label: '(UTC) Casablanca',
+    },
+    {
+        value: 'Europe/Berlin',
+        label: '(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna',
+    },
+    {
+        value: 'Europe/Budapest',
+        label: '(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague',
+    },
+    {
+        value: 'Europe/Paris',
+        label: '(UTC+01:00) Brussels, Copenhagen, Madrid, Paris',
+    },
+    {
+        value: 'Europe/Warsaw',
+        label: '(UTC+01:00) Sarajevo, Skopje, Warsaw, Zagreb',
+    },
+    {
+        value: 'Africa/Lagos',
+        label: '(UTC+01:00) West Central Africa',
+    },
+    {
+        value: 'Africa/Windhoek',
+        label: '(UTC+01:00) Windhoek',
+    },
+    {
+        value: 'Asia/Amman',
+        label: '(UTC+02:00) Amman',
+    },
+    {
+        value: 'Europe/Bucharest',
+        label: '(UTC+02:00) Athens, Bucharest',
+    },
+    {
+        value: 'Asia/Beirut',
+        label: '(UTC+02:00) Beirut',
+    },
+    {
+        value: 'Africa/Cairo',
+        label: '(UTC+02:00) Cairo',
+    },
+    {
+        value: 'Asia/Damascus',
+        label: '(UTC+02:00) Damascus',
+    },
+    {
+        value: 'Europe/Chisinau',
+        label: '(UTC+02:00) E. Europe',
+    },
+    {
+        value: 'Africa/Johannesburg',
+        label: '(UTC+02:00) Harare, Pretoria',
+    },
+    {
+        value: 'Europe/Kiev',
+        label: '(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius',
+    },
+    {
+        value: 'Europe/Istanbul',
+        label: '(UTC+02:00) Istanbul',
+    },
+    {
+        value: 'Asia/Jerusalem',
+        label: '(UTC+02:00) Jerusalem',
+    },
+    {
+        value: 'Europe/Kaliningrad',
+        label: '(UTC+02:00) Kaliningrad (RTZ 1)',
+    },
+    {
+        value: 'Africa/Tripoli',
+        label: '(UTC+02:00) Tripoli',
+    },
+    {
+        value: 'Asia/Baghdad',
+        label: '(UTC+03:00) Baghdad',
+    },
+    {
+        value: 'Asia/Riyadh',
+        label: '(UTC+03:00) Kuwait, Riyadh',
+    },
+    {
+        value: 'Europe/Minsk',
+        label: '(UTC+03:00) Minsk',
+    },
+    {
+        value: 'Europe/Moscow',
+        label: '(UTC+03:00) Moscow, St. Petersburg, Volgograd (RTZ 2)',
+    },
+    {
+        value: 'Africa/Nairobi',
+        label: '(UTC+03:00) Nairobi',
+    },
+    {
+        value: 'Asia/Tehran',
+        label: '(UTC+03:30) Tehran',
+    },
+    {
+        value: 'Asia/Dubai',
+        label: '(UTC+04:00) Abu Dhabi, Muscat',
+    },
+    {
+        value: 'Asia/Baku',
+        label: '(UTC+04:00) Baku',
+    },
+    {
+        value: 'Europe/Samara',
+        label: '(UTC+04:00) Izhevsk, Samara (RTZ 3)',
+    },
+    {
+        value: 'Indian/Mauritius',
+        label: '(UTC+04:00) Port Louis',
+    },
+    {
+        value: 'Asia/Tbilisi',
+        label: '(UTC+04:00) Tbilisi',
+    },
+    {
+        value: 'Asia/Yerevan',
+        label: '(UTC+04:00) Yerevan',
+    },
+    {
+        value: 'Asia/Kabul',
+        label: '(UTC+04:30) Kabul',
+    },
+    {
+        value: 'Asia/Tashkent',
+        label: '(UTC+05:00) Ashgabat, Tashkent',
+    },
+    {
+        value: 'Asia/Yekaterinburg',
+        label: '(UTC+05:00) Ekaterinburg (RTZ 4)',
+    },
+    {
+        value: 'Asia/Karachi',
+        label: '(UTC+05:00) Islamabad, Karachi',
+    },
+    {
+        value: 'Asia/Kolkata',
+        label: '(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi',
+    },
+    {
+        value: 'Asia/Colombo',
+        label: '(UTC+05:30) Sri Jayawardenepura',
+    },
+    {
+        value: 'Asia/Katmandu',
+        label: '(UTC+05:45) Kathmandu',
+    },
+    {
+        value: 'Asia/Almaty',
+        label: '(UTC+06:00) Astana',
+    },
+    {
+        value: 'Asia/Dhaka',
+        label: '(UTC+06:00) Dhaka',
+    },
+    {
+        value: 'Asia/Novosibirsk',
+        label: '(UTC+06:00) Novosibirsk (RTZ 5)',
+    },
+    {
+        value: 'Asia/Rangoon',
+        label: '(UTC+06:30) Yangon (Rangoon)',
+    },
+    {
+        value: 'Asia/Bangkok',
+        label: '(UTC+07:00) Bangkok, Hanoi, Jakarta',
+    },
+    {
+        value: 'Asia/Krasnoyarsk',
+        label: '(UTC+07:00) Krasnoyarsk (RTZ 6)',
+    },
+    {
+        value: 'Asia/Shanghai',
+        label: '(UTC+08:00) Beijing, Chongqing, Urumqi',
+    },
+    {
+        value: 'Asia/Hong_Kong',
+        label: '(UTC+08:00) Hong Kong',
+    },
+    {
+        value: 'Asia/Irkutsk',
+        label: '(UTC+08:00) Irkutsk (RTZ 7)',
+    },
+    {
+        value: 'Asia/Singapore',
+        label: '(UTC+08:00) Kuala Lumpur, Singapore',
+    },
+    {
+        value: 'Asia/Manila',
+        label: '(UTC+08:00) Manila (Philippines)',
+    },
+    {
+        value: 'Australia/Perth',
+        label: '(UTC+08:00) Perth',
+    },
+    {
+        value: 'Asia/Taipei',
+        label: '(UTC+08:00) Taipei',
+    },
+    {
+        value: 'Asia/Ulaanbaatar',
+        label: '(UTC+08:00) Ulaanbaatar',
+    },
+    {
+        value: 'Asia/Tokyo',
+        label: '(UTC+09:00) Osaka, Sapporo, Tokyo',
+    },
+    {
+        value: 'Asia/Seoul',
+        label: '(UTC+09:00) Seoul',
+    },
+    {
+        value: 'Asia/Yakutsk',
+        label: '(UTC+09:00) Yakutsk (RTZ 8)',
+    },
+    {
+        value: 'Australia/Adelaide',
+        label: '(UTC+09:30) Adelaide',
+    },
+    {
+        value: 'Australia/Darwin',
+        label: '(UTC+09:30) Darwin',
+    },
+    {
+        value: 'Australia/Brisbane',
+        label: '(UTC+10:00) Brisbane',
+    },
+    {
+        value: 'Australia/Sydney',
+        label: '(UTC+10:00) Canberra, Melbourne, Sydney',
+    },
+    {
+        value: 'Pacific/Port_Moresby',
+        label: '(UTC+10:00) Guam, Port Moresby',
+    },
+    {
+        value: 'Australia/Hobart',
+        label: '(UTC+10:00) Hobart',
+    },
+    {
+        value: 'Asia/Magadan',
+        label: '(UTC+10:00) Magadan',
+    },
+    {
+        value: 'Asia/Vladivostok',
+        label: '(UTC+10:00) Vladivostok, Magadan (RTZ 9)',
+    },
+    {
+        value: 'Asia/Srednekolymsk',
+        label: '(UTC+11:00) Chokurdakh (RTZ 10)',
+    },
+    {
+        value: 'Pacific/Guadalcanal',
+        label: '(UTC+11:00) Solomon Is., New Caledonia',
+    },
+    {
+        value: 'Asia/Kamchatka',
+        label: '(UTC+12:00) Anadyr, Petropavlovsk-Kamchatsky (RTZ 11)',
+    },
+    {
+        value: 'Pacific/Auckland',
+        label: '(UTC+12:00) Auckland, Wellington',
+    },
+    {
+        value: 'Etc/GMT-12',
+        label: '(UTC+12:00) Coordinated Universal Time+12',
+    },
+    {
+        value: 'Pacific/Fiji',
+        label: '(UTC+12:00) Fiji',
+    },
+    {
+        value: 'Pacific/Tongatapu',
+        label: '(UTC+13:00) Nuku\'alofa',
+    },
+    {
+        value: 'Pacific/Apia',
+        label: '(UTC+13:00) Samoa',
+    },
+    {
+        value: 'Pacific/Kiritimati',
+        label: '(UTC+14:00) Kiritimati Island',
+    },
+];

--- a/docs/src/inputs/timePicker/devSandbox/devSandbox.jsx
+++ b/docs/src/inputs/timePicker/devSandbox/devSandbox.jsx
@@ -1,0 +1,123 @@
+import {
+    Typography,
+} from 'react-cm-ui';
+import {
+    camelCase,
+} from 'lodash';
+import React from 'react';
+import Example from '../../../global/example';
+import ExampleDisabledTimePicker from '../examples/exampleDisabledTimePicker';
+import ExampleNestedTimePicker from '../examples/exampleNestedTimePicker';
+import ExampleRangeTimePicker from '../examples/exampleRangeTimePicker';
+import ExampleTimePickerWithCustomTimeZoneOptions from '../examples/exampleTimePickerWithCustomTimeZoneOptions';
+import ExampleTimePickerWithoutTimeZoneSelect from '../examples/exampleTimePickerWithoutTimeZoneSelect';
+import ExampleTimePickerWithZoneMatchProp from '../examples/exampleTimePickerWithZoneMatchProp';
+import Heading from '../../../global/heading';
+import Main from '../../../global/main';
+import MarkdownContainer from '../../../global/markdownContainer';
+/* eslint-disable import/no-named-default, import/extensions */
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/select/select';
+/* eslint-enable import/no-named-default, import/extensions */
+
+function TimePickerDevSandbox() {
+    const {
+        description,
+        displayName,
+    } = rootDoc;
+
+    return (
+        <Main page={camelCase(displayName)}>
+            <Main.Content>
+                <MarkdownContainer>
+                    <Typography
+                        className="description"
+                        variant="body1"
+                    >
+                        {description}
+                    </Typography>
+
+                    <Heading
+                        anchorLink="time-picker-disabled"
+                        variant="h2"
+                    >
+                        Disabled Time Picker
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!../examples/exampleDisabledTimePicker').default}
+                    >
+                        <ExampleDisabledTimePicker />
+                    </Example>
+
+                    <Heading
+                        anchorLink="time-picker-nested"
+                        variant="h2"
+                    >
+                        Nested Time Picker
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!../examples/exampleNestedTimePicker').default}
+                    >
+                        <ExampleNestedTimePicker />
+                    </Example>
+
+                    <Heading
+                        anchorLink="time-picker-range"
+                        variant="h2"
+                    >
+                        Time Range
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!../examples/exampleRangeTimePicker').default}
+                    >
+                        <ExampleRangeTimePicker />
+                    </Example>
+
+                    <Heading
+                        anchorLink="time-picker-custom-time-zone-options"
+                        variant="h2"
+                    >
+                        Custom Time Zone Options
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!../examples/exampleTimePickerWithCustomTimeZoneOptions').default}
+                    >
+                        <ExampleTimePickerWithCustomTimeZoneOptions />
+                    </Example>
+
+                    <Heading
+                        anchorLink="time-picker-zone-match-prop"
+                        variant="h2"
+                    >
+                        Zone Match Prop
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!../examples/exampleTimePickerWithZoneMatchProp').default}
+                    >
+                        <ExampleTimePickerWithZoneMatchProp />
+                    </Example>
+
+                    <Heading
+                        anchorLink="time-picker-suppress-time-zone-select"
+                        variant="h2"
+                    >
+                        Suppress Time Zone Select
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!../examples/exampleTimePickerWithoutTimeZoneSelect').default}
+                    >
+                        <ExampleTimePickerWithoutTimeZoneSelect />
+                    </Example>
+
+                </MarkdownContainer>
+            </Main.Content>
+        </Main>
+    );
+}
+
+export default TimePickerDevSandbox;

--- a/docs/src/inputs/timePicker/devSandbox/index.js
+++ b/docs/src/inputs/timePicker/devSandbox/index.js
@@ -1,0 +1,1 @@
+export { default } from './devSandbox';

--- a/docs/src/inputs/timePicker/examples/exampleDefaultTimePicker.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleDefaultTimePicker.jsx
@@ -1,4 +1,7 @@
-import { TimePicker } from 'react-cm-ui';
+import {
+    Grid,
+    TimePicker,
+} from 'react-cm-ui';
 import React, { useState } from 'react';
 
 function ExampleDefaultTimePicker() {
@@ -15,12 +18,21 @@ function ExampleDefaultTimePicker() {
                 value={value}
             />
 
-            <dl>
-                <dt>Time:</dt>
-                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
-                <dt>Time Zone:</dt>
-                <dd>{value?.timeZone?.label ?? '<NULL>'}</dd>
-            </dl>
+            <Grid spacing={1} style={{ marginTop: 22 }}>
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {value?.timeFrom ?? '<NULL>'}
+                </Grid.Column>
+
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time Zone:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {value?.timeZone?.label ?? '<NULL>'}
+                </Grid.Column>
+            </Grid>
         </React.Fragment>
     );
 }

--- a/docs/src/inputs/timePicker/examples/exampleDefaultTimePicker.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleDefaultTimePicker.jsx
@@ -1,0 +1,28 @@
+import { TimePicker } from 'react-cm-ui';
+import React, { useState } from 'react';
+
+function ExampleDefaultTimePicker() {
+    const [value, setValue] = useState(null);
+
+    const onTimePickerChange = (updatedValue) => {
+        setValue(updatedValue);
+    };
+
+    return (
+        <React.Fragment>
+            <TimePicker
+                onChange={onTimePickerChange}
+                value={value}
+            />
+
+            <dl>
+                <dt>Time:</dt>
+                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
+                <dt>Time Zone:</dt>
+                <dd>{value?.timeZone?.label ?? '<NULL>'}</dd>
+            </dl>
+        </React.Fragment>
+    );
+}
+
+export default ExampleDefaultTimePicker;

--- a/docs/src/inputs/timePicker/examples/exampleDisabledTimePicker.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleDisabledTimePicker.jsx
@@ -1,0 +1,20 @@
+import { TimePicker } from 'react-cm-ui';
+import React, { useState } from 'react';
+
+function ExampleDisabledTimePicker() {
+    const [value, setValue] = useState(null);
+
+    const onTimePickerChange = (updatedValue) => {
+        setValue(updatedValue);
+    };
+
+    return (
+        <TimePicker
+            disable
+            onChange={onTimePickerChange}
+            value={value}
+        />
+    );
+}
+
+export default ExampleDisabledTimePicker;

--- a/docs/src/inputs/timePicker/examples/exampleNestedTimePicker.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleNestedTimePicker.jsx
@@ -1,0 +1,20 @@
+import { TimePicker } from 'react-cm-ui';
+import React, { useState } from 'react';
+
+function ExampleNestedTimePicker() {
+    const [value, setValue] = useState(null);
+
+    const onTimePickerChange = (updatedValue) => {
+        setValue(updatedValue);
+    };
+
+    return (
+        <TimePicker
+            nest
+            onChange={onTimePickerChange}
+            value={value}
+        />
+    );
+}
+
+export default ExampleNestedTimePicker;

--- a/docs/src/inputs/timePicker/examples/exampleRangeTimePicker.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleRangeTimePicker.jsx
@@ -1,0 +1,33 @@
+import { TimePicker } from 'react-cm-ui';
+import React, { useState } from 'react';
+
+function ExampleDefaultTimePicker() {
+    const [rangeValue, setRangeValue] = useState(null);
+
+    const onTimePickerChange = (updatedValue) => {
+        setRangeValue(updatedValue);
+    };
+
+    return (
+        <React.Fragment>
+            <TimePicker
+                onChange={onTimePickerChange}
+                range
+                value={rangeValue}
+            />
+
+            <dl>
+                <dt>Time Zone:</dt>
+                <dd>{rangeValue?.timeZone?.label ?? '<NULL>'}</dd>
+
+                <dt>Time From:</dt>
+                <dd>{rangeValue?.timeFrom ?? '<NULL>'}</dd>
+
+                <dt>Time To:</dt>
+                <dd>{rangeValue?.timeTo ?? '<NULL>'}</dd>
+            </dl>
+        </React.Fragment>
+    );
+}
+
+export default ExampleDefaultTimePicker;

--- a/docs/src/inputs/timePicker/examples/exampleRangeTimePicker.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleRangeTimePicker.jsx
@@ -1,4 +1,7 @@
-import { TimePicker } from 'react-cm-ui';
+import {
+    Grid,
+    TimePicker,
+} from 'react-cm-ui';
 import React, { useState } from 'react';
 
 function ExampleDefaultTimePicker() {
@@ -16,16 +19,28 @@ function ExampleDefaultTimePicker() {
                 value={rangeValue}
             />
 
-            <dl>
-                <dt>Time Zone:</dt>
-                <dd>{rangeValue?.timeZone?.label ?? '<NULL>'}</dd>
+            <Grid spacing={1} style={{ marginTop: 22 }}>
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time Zone:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {rangeValue?.timeZone?.label ?? '<NULL>'}
+                </Grid.Column>
 
-                <dt>Time From:</dt>
-                <dd>{rangeValue?.timeFrom ?? '<NULL>'}</dd>
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time From:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {rangeValue?.timeFrom ?? '<NULL>'}
+                </Grid.Column>
 
-                <dt>Time To:</dt>
-                <dd>{rangeValue?.timeTo ?? '<NULL>'}</dd>
-            </dl>
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time To:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {rangeValue?.timeTo ?? '<NULL>'}
+                </Grid.Column>
+            </Grid>
         </React.Fragment>
     );
 }

--- a/docs/src/inputs/timePicker/examples/exampleTimePickerWithCustomTimeZoneOptions.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleTimePickerWithCustomTimeZoneOptions.jsx
@@ -1,0 +1,30 @@
+import { TimePicker } from 'react-cm-ui';
+import React, { useState } from 'react';
+import { CUSTOM_TIME_ZONE_SELECT_OPTIONS } from '../constants';
+
+function ExampleTimePickerWithCustomTimeZoneOptions() {
+    const [value, setValue] = useState(null);
+
+    const onTimePickerChange = (updatedValue) => {
+        setValue(updatedValue);
+    };
+
+    return (
+        <React.Fragment>
+            <TimePicker
+                onChange={onTimePickerChange}
+                value={value}
+                zoneOptions={CUSTOM_TIME_ZONE_SELECT_OPTIONS}
+            />
+
+            <dl>
+                <dt>Time:</dt>
+                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
+                <dt>Time Zone:</dt>
+                <dd>{value?.timeZone?.label ?? '<NULL>'}</dd>
+            </dl>
+        </React.Fragment>
+    );
+}
+
+export default ExampleTimePickerWithCustomTimeZoneOptions;

--- a/docs/src/inputs/timePicker/examples/exampleTimePickerWithCustomTimeZoneOptions.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleTimePickerWithCustomTimeZoneOptions.jsx
@@ -1,4 +1,7 @@
-import { TimePicker } from 'react-cm-ui';
+import {
+    Grid,
+    TimePicker,
+} from 'react-cm-ui';
 import React, { useState } from 'react';
 import { CUSTOM_TIME_ZONE_SELECT_OPTIONS } from '../constants';
 
@@ -17,12 +20,21 @@ function ExampleTimePickerWithCustomTimeZoneOptions() {
                 zoneOptions={CUSTOM_TIME_ZONE_SELECT_OPTIONS}
             />
 
-            <dl>
-                <dt>Time:</dt>
-                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
-                <dt>Time Zone:</dt>
-                <dd>{value?.timeZone?.label ?? '<NULL>'}</dd>
-            </dl>
+            <Grid spacing={1} style={{ marginTop: 22 }}>
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {value?.timeFrom ?? '<NULL>'}
+                </Grid.Column>
+
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time Zone:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {value?.timeZone?.label ?? '<NULL>'}
+                </Grid.Column>
+            </Grid>
         </React.Fragment>
     );
 }

--- a/docs/src/inputs/timePicker/examples/exampleTimePickerWithZoneMatchProp.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleTimePickerWithZoneMatchProp.jsx
@@ -1,0 +1,31 @@
+import { TimePicker } from 'react-cm-ui';
+import React, { useState } from 'react';
+import { CUSTOM_TIME_ZONE_SELECT_OPTIONS } from '../constants';
+
+function ExampleTimePickerWithZoneMatchProp() {
+    const [value, setValue] = useState(null);
+
+    const onTimePickerChange = (updatedValue) => {
+        setValue(updatedValue);
+    };
+
+    return (
+        <React.Fragment>
+            <TimePicker
+                onChange={onTimePickerChange}
+                value={value}
+                zoneMatchProp="label"
+                zoneOptions={CUSTOM_TIME_ZONE_SELECT_OPTIONS}
+            />
+
+            <dl>
+                <dt>Time:</dt>
+                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
+                <dt>Time Zone:</dt>
+                <dd>{value?.timeZone?.label ?? '<NULL>'}</dd>
+            </dl>
+        </React.Fragment>
+    );
+}
+
+export default ExampleTimePickerWithZoneMatchProp;

--- a/docs/src/inputs/timePicker/examples/exampleTimePickerWithZoneMatchProp.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleTimePickerWithZoneMatchProp.jsx
@@ -1,4 +1,7 @@
-import { TimePicker } from 'react-cm-ui';
+import {
+    Grid,
+    TimePicker,
+} from 'react-cm-ui';
 import React, { useState } from 'react';
 import { CUSTOM_TIME_ZONE_SELECT_OPTIONS } from '../constants';
 
@@ -18,12 +21,21 @@ function ExampleTimePickerWithZoneMatchProp() {
                 zoneOptions={CUSTOM_TIME_ZONE_SELECT_OPTIONS}
             />
 
-            <dl>
-                <dt>Time:</dt>
-                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
-                <dt>Time Zone:</dt>
-                <dd>{value?.timeZone?.label ?? '<NULL>'}</dd>
-            </dl>
+            <Grid spacing={1} style={{ marginTop: 22 }}>
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {value?.timeFrom ?? '<NULL>'}
+                </Grid.Column>
+
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time Zone:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {value?.timeZone?.label ?? '<NULL>'}
+                </Grid.Column>
+            </Grid>
         </React.Fragment>
     );
 }

--- a/docs/src/inputs/timePicker/examples/exampleTimePickerWithoutTimeZoneSelect.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleTimePickerWithoutTimeZoneSelect.jsx
@@ -1,4 +1,7 @@
-import { TimePicker } from 'react-cm-ui';
+import {
+    Grid,
+    TimePicker,
+} from 'react-cm-ui';
 import React, { useState } from 'react';
 
 function ExampleTimePickerWithoutTimeZoneSelect() {
@@ -16,10 +19,14 @@ function ExampleTimePickerWithoutTimeZoneSelect() {
                 value={value}
             />
 
-            <dl>
-                <dt>Time:</dt>
-                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
-            </dl>
+            <Grid spacing={1} style={{ marginTop: 22 }}>
+                <Grid.Column sm={2} style={{ fontWeight: 'bold' }}>
+                    Time:
+                </Grid.Column>
+                <Grid.Column sm={10}>
+                    {value?.timeFrom ?? '<NULL>'}
+                </Grid.Column>
+            </Grid>
         </React.Fragment>
     );
 }

--- a/docs/src/inputs/timePicker/examples/exampleTimePickerWithoutTimeZoneSelect.jsx
+++ b/docs/src/inputs/timePicker/examples/exampleTimePickerWithoutTimeZoneSelect.jsx
@@ -1,0 +1,27 @@
+import { TimePicker } from 'react-cm-ui';
+import React, { useState } from 'react';
+
+function ExampleTimePickerWithoutTimeZoneSelect() {
+    const [value, setValue] = useState(null);
+
+    const onTimePickerChange = (updatedValue) => {
+        setValue(updatedValue);
+    };
+
+    return (
+        <React.Fragment>
+            <TimePicker
+                onChange={onTimePickerChange}
+                showTimezone={false}
+                value={value}
+            />
+
+            <dl>
+                <dt>Time:</dt>
+                <dd>{value?.timeFrom ?? '<NULL>'}</dd>
+            </dl>
+        </React.Fragment>
+    );
+}
+
+export default ExampleTimePickerWithoutTimeZoneSelect;

--- a/docs/src/inputs/timePicker/timePicker.jsx
+++ b/docs/src/inputs/timePicker/timePicker.jsx
@@ -1,413 +1,72 @@
 import {
-    Card,
-    Header,
-    TimePicker,
+    Typography,
 } from 'react-cm-ui';
+import {
+    camelCase,
+} from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
-import Block from '../../global/block';
-import Highlighter from '../../global/highlighter';
+import ComponentVersionIdentifier from '../../global/componentVersionIdentifier';
+import Example from '../../global/example';
+import ExampleDefaultTimePicker from './examples/exampleDefaultTimePicker';
+import Heading from '../../global/heading';
 import Main from '../../global/main';
-import TableProps from '../../global/tableProps';
+import MarkdownContainer from '../../global/markdownContainer';
+/* eslint-disable import/no-named-default, import/extensions */
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/timePicker/timePicker';
+/* eslint-enable import/no-named-default, import/extensions */
 
-const timePickerSample = `import React from 'react';
+const propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string,
+    }).isRequired,
+};
 
-import { TimePicker } from 'react-cm-ui';
+function DocsTimePicker(props) {
+    const {
+        location: {
+            pathname,
+        },
+    } = props;
 
-export default class TimePickerSample extends React.Component {
+    const {
+        description,
+        displayName,
+    } = rootDoc;
 
-    constructor(props) {
-        super(props);
+    return (
+        <Main page={camelCase(displayName)}>
+            <Main.Content>
+                <MarkdownContainer>
+                    <Typography
+                        className="description"
+                        variant="body1"
+                    >
+                        {description}
+                    </Typography>
 
-        this.state = { value: null };
-    }
+                    <Heading
+                        anchorLink="time-picker-default"
+                        variant="h2"
+                    >
+                        Default TimePicker
+                    </Heading>
 
-    render() {
-        return (
-            <TimePicker
-                onChange={this._onTimePickerChange.bind(this)}
-                value={this.state.value}
-            />
-        );
-    }
+                    <Example
+                        rawCode={require('!!raw-loader!./examples/exampleDefaultTimePicker').default}
+                    >
+                        <ExampleDefaultTimePicker />
+                    </Example>
+                </MarkdownContainer>
 
-    _onTimePickerChange(value) {
-        this.setState({ value: value });
-    }
-
-}`;
-
-const disableSample = `import React from 'react';
-
-import { TimePicker } from 'react-cm-ui';
-
-export default class DisableSample extends React.Component {
-
-    constructor(props) {
-        super(props);
-
-        this.state = { value: null };
-    }
-
-    render() {
-        return (
-            <TimePicker
-                disable
-                onChange={this._onTimePickerChange.bind(this)}
-                value={this.state.value}
-            />
-        );
-    }
-
-    _onTimePickerChange(value) {
-        this.setState({ value: value });
-    }
-
-}`;
-
-const nestSample = `import React from 'react';
-
-import { TimePicker } from 'react-cm-ui';
-
-export default class NestSample extends React.Component {
-
-    constructor(props) {
-        super(props);
-
-        this.state = { nestValue: null };
-    }
-
-    render() {
-        return (
-            <div className="some-class-that-has-nested-bkgd-color">
-                <TimePicker
-                    nest
-                    onChange={this._onNestChange.bind(this)}
-                    value={this.state.nestValue}
+                <ComponentVersionIdentifier
+                    pathname={pathname}
                 />
-            </div>
-        );
-    }
-
-    _onNestChange(value) {
-        this.setState({ nestValue: value });
-    }
-
-}`;
-
-const rangeSample = `import React from 'react';
-import { TimePicker } from 'react-cm-ui';
-
-export default class RangeSample extends React.Component {
-
-    constructor(props) {
-        super(props);
-
-        this.state = { rangeValue: null };
-    }
-
-    render() {
-        return (
-            <TimePicker
-                onChange={this._onRangeChange.bind(this)}
-                range
-                value={this.state.rangeValue}
-            />
-        );
-    }
-
-    _onRangeChange(value) {
-        this.setState({ rangeValue: value });
-    }
-}`;
-
-const zoneOptionsSample = `import React from 'react';
-import { TimePicker } from 'react-cm-ui';
-
-export default class ZoneOptionsSample extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = { value: null };
-    }
-
-    render() {
-        const customZoneOptions = [{"value":"Etc/GMT+12","label":"(UTC-12:00) International Date Line West"},{"value":"Etc/GMT+11","label":"(UTC-11:00) Coordinated Universal Time-11"},{"value":"Pacific/Honolulu","label":"(UTC-10:00) Hawaii"},{"value":"America/Anchorage","label":"(UTC-09:00) Alaska"},{"value":"America/Tijuana","label":"(UTC-08:00) Baja California"},{"value":"America/Los_Angeles","label":"(UTC-08:00) Pacific Time (US & Canada)"},{"value":"America/Phoenix","label":"(UTC-07:00) Arizona"},{"value":"America/Chihuahua","label":"(UTC-07:00) Chihuahua, La Paz, Mazatlan"},{"value":"America/Denver","label":"(UTC-07:00) Mountain Time (US & Canada)"},{"value":"America/Guatemala","label":"(UTC-06:00) Central America"},{"value":"America/Chicago","label":"(UTC-06:00) Central Time (US & Canada)"},{"value":"America/Mexico_City","label":"(UTC-06:00) Guadalajara, Mexico City, Monterrey"},{"value":"America/Regina","label":"(UTC-06:00) Saskatchewan"},{"value":"America/Bogota","label":"(UTC-05:00) Bogota, Lima, Quito, Rio Branco"},{"value":"America/Cancun","label":"(UTC-05:00) Chetumal"},{"value":"America/New_York","label":"(UTC-05:00) Eastern Time (US & Canada)"},{"value":"America/Indianapolis","label":"(UTC-05:00) Indiana (East)"},{"value":"America/Caracas","label":"(UTC-04:30) Caracas"},{"value":"America/Asuncion","label":"(UTC-04:00) Asuncion"},{"value":"America/Halifax","label":"(UTC-04:00) Atlantic Time (Canada)"},{"value":"America/Cuiaba","label":"(UTC-04:00) Cuiaba"},{"value":"America/La_Paz","label":"(UTC-04:00) Georgetown, La Paz, Manaus, San Juan"},{"value":"America/St_Johns","label":"(UTC-03:30) Newfoundland"},{"value":"America/Sao_Paulo","label":"(UTC-03:00) Brasilia"},{"value":"America/Argentina/Buenos_Aires","label":"(UTC-03:00) Buenos Aires"},{"value":"America/Cayenne","label":"(UTC-03:00) Cayenne, Fortaleza"},{"value":"America/Godthab","label":"(UTC-03:00) Greenland"},{"value":"America/Montevideo","label":"(UTC-03:00) Montevideo"},{"value":"America/Bahia","label":"(UTC-03:00) Salvador"},{"value":"America/Santiago","label":"(UTC-03:00) Santiago"},{"value":"Etc/GMT+2","label":"(UTC-02:00) Coordinated Universal Time-02"},{"value":"Atlantic/Azores","label":"(UTC-01:00) Azores"},{"value":"Atlantic/Cape_Verde","label":"(UTC-01:00) Cabo Verde Is."},{"value":"Europe/London","label":"(UTC) Dublin, Edinburgh, Lisbon, London"},{"value":"Atlantic/Reykjavik","label":"(UTC) Monrovia, Reykjavik"},{"value":"Etc/GMT","label":"UTC"},{"value":"Africa/Casablanca","label":"(UTC) Casablanca"},{"value":"Europe/Berlin","label":"(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"},{"value":"Europe/Budapest","label":"(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague"},{"value":"Europe/Paris","label":"(UTC+01:00) Brussels, Copenhagen, Madrid, Paris"},{"value":"Europe/Warsaw","label":"(UTC+01:00) Sarajevo, Skopje, Warsaw, Zagreb"},{"value":"Africa/Lagos","label":"(UTC+01:00) West Central Africa"},{"value":"Africa/Windhoek","label":"(UTC+01:00) Windhoek"},{"value":"Asia/Amman","label":"(UTC+02:00) Amman"},{"value":"Europe/Bucharest","label":"(UTC+02:00) Athens, Bucharest"},{"value":"Asia/Beirut","label":"(UTC+02:00) Beirut"},{"value":"Africa/Cairo","label":"(UTC+02:00) Cairo"},{"value":"Asia/Damascus","label":"(UTC+02:00) Damascus"},{"value":"Europe/Chisinau","label":"(UTC+02:00) E. Europe"},{"value":"Africa/Johannesburg","label":"(UTC+02:00) Harare, Pretoria"},{"value":"Europe/Kiev","label":"(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius"},{"value":"Europe/Istanbul","label":"(UTC+02:00) Istanbul"},{"value":"Asia/Jerusalem","label":"(UTC+02:00) Jerusalem"},{"value":"Europe/Kaliningrad","label":"(UTC+02:00) Kaliningrad (RTZ 1)"},{"value":"Africa/Tripoli","label":"(UTC+02:00) Tripoli"},{"value":"Asia/Baghdad","label":"(UTC+03:00) Baghdad"},{"value":"Asia/Riyadh","label":"(UTC+03:00) Kuwait, Riyadh"},{"value":"Europe/Minsk","label":"(UTC+03:00) Minsk"},{"value":"Europe/Moscow","label":"(UTC+03:00) Moscow, St. Petersburg, Volgograd (RTZ 2)"},{"value":"Africa/Nairobi","label":"(UTC+03:00) Nairobi"},{"value":"Asia/Tehran","label":"(UTC+03:30) Tehran"},{"value":"Asia/Dubai","label":"(UTC+04:00) Abu Dhabi, Muscat"},{"value":"Asia/Baku","label":"(UTC+04:00) Baku"},{"value":"Europe/Samara","label":"(UTC+04:00) Izhevsk, Samara (RTZ 3)"},{"value":"Indian/Mauritius","label":"(UTC+04:00) Port Louis"},{"value":"Asia/Tbilisi","label":"(UTC+04:00) Tbilisi"},{"value":"Asia/Yerevan","label":"(UTC+04:00) Yerevan"},{"value":"Asia/Kabul","label":"(UTC+04:30) Kabul"},{"value":"Asia/Tashkent","label":"(UTC+05:00) Ashgabat, Tashkent"},{"value":"Asia/Yekaterinburg","label":"(UTC+05:00) Ekaterinburg (RTZ 4)"},{"value":"Asia/Karachi","label":"(UTC+05:00) Islamabad, Karachi"},{"value":"Asia/Kolkata","label":"(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi"},{"value":"Asia/Colombo","label":"(UTC+05:30) Sri Jayawardenepura"},{"value":"Asia/Katmandu","label":"(UTC+05:45) Kathmandu"},{"value":"Asia/Almaty","label":"(UTC+06:00) Astana"},{"value":"Asia/Dhaka","label":"(UTC+06:00) Dhaka"},{"value":"Asia/Novosibirsk","label":"(UTC+06:00) Novosibirsk (RTZ 5)"},{"value":"Asia/Rangoon","label":"(UTC+06:30) Yangon (Rangoon)"},{"value":"Asia/Bangkok","label":"(UTC+07:00) Bangkok, Hanoi, Jakarta"},{"value":"Asia/Krasnoyarsk","label":"(UTC+07:00) Krasnoyarsk (RTZ 6)"},{"value":"Asia/Shanghai","label":"(UTC+08:00) Beijing, Chongqing, Urumqi"},{"value":"Asia/Hong_Kong","label":"(UTC+08:00) Hong Kong"},{"value":"Asia/Irkutsk","label":"(UTC+08:00) Irkutsk (RTZ 7)"},{"value":"Asia/Singapore","label":"(UTC+08:00) Kuala Lumpur, Singapore"},{"value":"Asia/Manila","label":"(UTC+08:00) Manila (Philippines)"},{"value":"Australia/Perth","label":"(UTC+08:00) Perth"},{"value":"Asia/Taipei","label":"(UTC+08:00) Taipei"},{"value":"Asia/Ulaanbaatar","label":"(UTC+08:00) Ulaanbaatar"},{"value":"Asia/Tokyo","label":"(UTC+09:00) Osaka, Sapporo, Tokyo"},{"value":"Asia/Seoul","label":"(UTC+09:00) Seoul"},{"value":"Asia/Yakutsk","label":"(UTC+09:00) Yakutsk (RTZ 8)"},{"value":"Australia/Adelaide","label":"(UTC+09:30) Adelaide"},{"value":"Australia/Darwin","label":"(UTC+09:30) Darwin"},{"value":"Australia/Brisbane","label":"(UTC+10:00) Brisbane"},{"value":"Australia/Sydney","label":"(UTC+10:00) Canberra, Melbourne, Sydney"},{"value":"Pacific/Port_Moresby","label":"(UTC+10:00) Guam, Port Moresby"},{"value":"Australia/Hobart","label":"(UTC+10:00) Hobart"},{"value":"Asia/Magadan","label":"(UTC+10:00) Magadan"},{"value":"Asia/Vladivostok","label":"(UTC+10:00) Vladivostok, Magadan (RTZ 9)"},{"value":"Asia/Srednekolymsk","label":"(UTC+11:00) Chokurdakh (RTZ 10)"},{"value":"Pacific/Guadalcanal","label":"(UTC+11:00) Solomon Is., New Caledonia"},{"value":"Asia/Kamchatka","label":"(UTC+12:00) Anadyr, Petropavlovsk-Kamchatsky (RTZ 11)"},{"value":"Pacific/Auckland","label":"(UTC+12:00) Auckland, Wellington"},{"value":"Etc/GMT-12","label":"(UTC+12:00) Coordinated Universal Time+12"},{"value":"Pacific/Fiji","label":"(UTC+12:00) Fiji"},{"value":"Pacific/Tongatapu","label":"(UTC+13:00) Nuku'alofa"},{"value":"Pacific/Apia","label":"(UTC+13:00) Samoa"},{"value":"Pacific/Kiritimati","label":"(UTC+14:00) Kiritimati Island"}];
-
-        return (
-            <TimePicker
-                onChange={this._onTimePickerChange.bind(this)}
-                value={this.state.value}
-                zoneOptions={customZoneOptions}
-                zoneMatchProp="label"
-            />
-        );
-    }
-
-    _onTimePickerChange(value) {
-        this.setState({ value: value });
-    }
-}`;
-
-const zoneMatchPropSample = `import React from 'react';
-import { TimePicker } from 'react-cm-ui';
-
-export default class ZoneMatchPropSample extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = { value: null };
-    }
-
-    render() {
-        const customZoneOptions = [{"value":"Etc/GMT+12","label":"(UTC-12:00) International Date Line West"},{"value":"Etc/GMT+11","label":"(UTC-11:00) Coordinated Universal Time-11"},{"value":"Pacific/Honolulu","label":"(UTC-10:00) Hawaii"},{"value":"America/Anchorage","label":"(UTC-09:00) Alaska"},{"value":"America/Tijuana","label":"(UTC-08:00) Baja California"},{"value":"America/Los_Angeles","label":"(UTC-08:00) Pacific Time (US & Canada)"},{"value":"America/Phoenix","label":"(UTC-07:00) Arizona"},{"value":"America/Chihuahua","label":"(UTC-07:00) Chihuahua, La Paz, Mazatlan"},{"value":"America/Denver","label":"(UTC-07:00) Mountain Time (US & Canada)"},{"value":"America/Guatemala","label":"(UTC-06:00) Central America"},{"value":"America/Chicago","label":"(UTC-06:00) Central Time (US & Canada)"},{"value":"America/Mexico_City","label":"(UTC-06:00) Guadalajara, Mexico City, Monterrey"},{"value":"America/Regina","label":"(UTC-06:00) Saskatchewan"},{"value":"America/Bogota","label":"(UTC-05:00) Bogota, Lima, Quito, Rio Branco"},{"value":"America/Cancun","label":"(UTC-05:00) Chetumal"},{"value":"America/New_York","label":"(UTC-05:00) Eastern Time (US & Canada)"},{"value":"America/Indianapolis","label":"(UTC-05:00) Indiana (East)"},{"value":"America/Caracas","label":"(UTC-04:30) Caracas"},{"value":"America/Asuncion","label":"(UTC-04:00) Asuncion"},{"value":"America/Halifax","label":"(UTC-04:00) Atlantic Time (Canada)"},{"value":"America/Cuiaba","label":"(UTC-04:00) Cuiaba"},{"value":"America/La_Paz","label":"(UTC-04:00) Georgetown, La Paz, Manaus, San Juan"},{"value":"America/St_Johns","label":"(UTC-03:30) Newfoundland"},{"value":"America/Sao_Paulo","label":"(UTC-03:00) Brasilia"},{"value":"America/Argentina/Buenos_Aires","label":"(UTC-03:00) Buenos Aires"},{"value":"America/Cayenne","label":"(UTC-03:00) Cayenne, Fortaleza"},{"value":"America/Godthab","label":"(UTC-03:00) Greenland"},{"value":"America/Montevideo","label":"(UTC-03:00) Montevideo"},{"value":"America/Bahia","label":"(UTC-03:00) Salvador"},{"value":"America/Santiago","label":"(UTC-03:00) Santiago"},{"value":"Etc/GMT+2","label":"(UTC-02:00) Coordinated Universal Time-02"},{"value":"Atlantic/Azores","label":"(UTC-01:00) Azores"},{"value":"Atlantic/Cape_Verde","label":"(UTC-01:00) Cabo Verde Is."},{"value":"Europe/London","label":"(UTC) Dublin, Edinburgh, Lisbon, London"},{"value":"Atlantic/Reykjavik","label":"(UTC) Monrovia, Reykjavik"},{"value":"Etc/GMT","label":"UTC"},{"value":"Africa/Casablanca","label":"(UTC) Casablanca"},{"value":"Europe/Berlin","label":"(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"},{"value":"Europe/Budapest","label":"(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague"},{"value":"Europe/Paris","label":"(UTC+01:00) Brussels, Copenhagen, Madrid, Paris"},{"value":"Europe/Warsaw","label":"(UTC+01:00) Sarajevo, Skopje, Warsaw, Zagreb"},{"value":"Africa/Lagos","label":"(UTC+01:00) West Central Africa"},{"value":"Africa/Windhoek","label":"(UTC+01:00) Windhoek"},{"value":"Asia/Amman","label":"(UTC+02:00) Amman"},{"value":"Europe/Bucharest","label":"(UTC+02:00) Athens, Bucharest"},{"value":"Asia/Beirut","label":"(UTC+02:00) Beirut"},{"value":"Africa/Cairo","label":"(UTC+02:00) Cairo"},{"value":"Asia/Damascus","label":"(UTC+02:00) Damascus"},{"value":"Europe/Chisinau","label":"(UTC+02:00) E. Europe"},{"value":"Africa/Johannesburg","label":"(UTC+02:00) Harare, Pretoria"},{"value":"Europe/Kiev","label":"(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius"},{"value":"Europe/Istanbul","label":"(UTC+02:00) Istanbul"},{"value":"Asia/Jerusalem","label":"(UTC+02:00) Jerusalem"},{"value":"Europe/Kaliningrad","label":"(UTC+02:00) Kaliningrad (RTZ 1)"},{"value":"Africa/Tripoli","label":"(UTC+02:00) Tripoli"},{"value":"Asia/Baghdad","label":"(UTC+03:00) Baghdad"},{"value":"Asia/Riyadh","label":"(UTC+03:00) Kuwait, Riyadh"},{"value":"Europe/Minsk","label":"(UTC+03:00) Minsk"},{"value":"Europe/Moscow","label":"(UTC+03:00) Moscow, St. Petersburg, Volgograd (RTZ 2)"},{"value":"Africa/Nairobi","label":"(UTC+03:00) Nairobi"},{"value":"Asia/Tehran","label":"(UTC+03:30) Tehran"},{"value":"Asia/Dubai","label":"(UTC+04:00) Abu Dhabi, Muscat"},{"value":"Asia/Baku","label":"(UTC+04:00) Baku"},{"value":"Europe/Samara","label":"(UTC+04:00) Izhevsk, Samara (RTZ 3)"},{"value":"Indian/Mauritius","label":"(UTC+04:00) Port Louis"},{"value":"Asia/Tbilisi","label":"(UTC+04:00) Tbilisi"},{"value":"Asia/Yerevan","label":"(UTC+04:00) Yerevan"},{"value":"Asia/Kabul","label":"(UTC+04:30) Kabul"},{"value":"Asia/Tashkent","label":"(UTC+05:00) Ashgabat, Tashkent"},{"value":"Asia/Yekaterinburg","label":"(UTC+05:00) Ekaterinburg (RTZ 4)"},{"value":"Asia/Karachi","label":"(UTC+05:00) Islamabad, Karachi"},{"value":"Asia/Kolkata","label":"(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi"},{"value":"Asia/Colombo","label":"(UTC+05:30) Sri Jayawardenepura"},{"value":"Asia/Katmandu","label":"(UTC+05:45) Kathmandu"},{"value":"Asia/Almaty","label":"(UTC+06:00) Astana"},{"value":"Asia/Dhaka","label":"(UTC+06:00) Dhaka"},{"value":"Asia/Novosibirsk","label":"(UTC+06:00) Novosibirsk (RTZ 5)"},{"value":"Asia/Rangoon","label":"(UTC+06:30) Yangon (Rangoon)"},{"value":"Asia/Bangkok","label":"(UTC+07:00) Bangkok, Hanoi, Jakarta"},{"value":"Asia/Krasnoyarsk","label":"(UTC+07:00) Krasnoyarsk (RTZ 6)"},{"value":"Asia/Shanghai","label":"(UTC+08:00) Beijing, Chongqing, Urumqi"},{"value":"Asia/Hong_Kong","label":"(UTC+08:00) Hong Kong"},{"value":"Asia/Irkutsk","label":"(UTC+08:00) Irkutsk (RTZ 7)"},{"value":"Asia/Singapore","label":"(UTC+08:00) Kuala Lumpur, Singapore"},{"value":"Asia/Manila","label":"(UTC+08:00) Manila (Philippines)"},{"value":"Australia/Perth","label":"(UTC+08:00) Perth"},{"value":"Asia/Taipei","label":"(UTC+08:00) Taipei"},{"value":"Asia/Ulaanbaatar","label":"(UTC+08:00) Ulaanbaatar"},{"value":"Asia/Tokyo","label":"(UTC+09:00) Osaka, Sapporo, Tokyo"},{"value":"Asia/Seoul","label":"(UTC+09:00) Seoul"},{"value":"Asia/Yakutsk","label":"(UTC+09:00) Yakutsk (RTZ 8)"},{"value":"Australia/Adelaide","label":"(UTC+09:30) Adelaide"},{"value":"Australia/Darwin","label":"(UTC+09:30) Darwin"},{"value":"Australia/Brisbane","label":"(UTC+10:00) Brisbane"},{"value":"Australia/Sydney","label":"(UTC+10:00) Canberra, Melbourne, Sydney"},{"value":"Pacific/Port_Moresby","label":"(UTC+10:00) Guam, Port Moresby"},{"value":"Australia/Hobart","label":"(UTC+10:00) Hobart"},{"value":"Asia/Magadan","label":"(UTC+10:00) Magadan"},{"value":"Asia/Vladivostok","label":"(UTC+10:00) Vladivostok, Magadan (RTZ 9)"},{"value":"Asia/Srednekolymsk","label":"(UTC+11:00) Chokurdakh (RTZ 10)"},{"value":"Pacific/Guadalcanal","label":"(UTC+11:00) Solomon Is., New Caledonia"},{"value":"Asia/Kamchatka","label":"(UTC+12:00) Anadyr, Petropavlovsk-Kamchatsky (RTZ 11)"},{"value":"Pacific/Auckland","label":"(UTC+12:00) Auckland, Wellington"},{"value":"Etc/GMT-12","label":"(UTC+12:00) Coordinated Universal Time+12"},{"value":"Pacific/Fiji","label":"(UTC+12:00) Fiji"},{"value":"Pacific/Tongatapu","label":"(UTC+13:00) Nuku'alofa"},{"value":"Pacific/Apia","label":"(UTC+13:00) Samoa"},{"value":"Pacific/Kiritimati","label":"(UTC+14:00) Kiritimati Island"}];
-
-        return (
-            <TimePicker
-                onChange={this._onTimePickerChange.bind(this)}
-                value={this.state.value}
-                zoneOptions={customZoneOptions}
-                zoneMatchProp="label"
-            />
-        );
-    }
-
-    _onTimePickerChange(value) {
-        this.setState({ value: value });
-    }
-}`;
-
-export default class ModulesTimePicker extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            nestValue: null,
-            rangeValue: null,
-            value: null
-        };
-    }
-
-    render() {
-        const props = [
-            {
-                name: 'className',
-                type: 'string',
-                default: '',
-                description: 'Additional classes.',
-                allowedTypes: ''
-            }, {
-                name: 'disable',
-                type: 'bool',
-                default: '',
-                description: 'Indicates that the Time Picker is not available for interaction.',
-                allowedTypes: ''
-            }, {
-                name: 'error',
-                type: 'bool || string',
-                default: '',
-                description: 'Indicates that the Time Picker has an error.',
-                allowedTypes: ''
-            }, {
-                name: 'id',
-                type: 'string',
-                default: '',
-                description: 'Give the Time Picker input an id.',
-                allowedTypes: ''
-            }, {
-                name: 'label',
-                type: 'string',
-                default: '',
-                description: 'Optional Label to display on top of the Time Picker.',
-                allowedTypes: ''
-            }, {
-                name: 'nest',
-                type: 'bool',
-                default: '',
-                description: 'Time Picker may be placed in a nested background color.',
-                allowedTypes: ''
-            }, {
-                name: 'onChange',
-                type: 'func',
-                default: '',
-                description: 'Can handle an onChange event from parent.',
-                allowedTypes: ''
-            }, {
-                name: 'value',
-                type: 'object',
-                default: '',
-                description: 'The initial value of the control.',
-                allowedTypes: ''
-            }, {
-                name: 'required',
-                type: 'bool',
-                default: '',
-                description: 'Specifies that the user must fill in a value before submitting a form.',
-                allowedTypes: ''
-            }, {
-                name: 'zoneOptions',
-                type: 'array',
-                default: '',
-                description: 'Provide a custom list of timezones to the Time Picker.',
-                allowedTypes: ''
-            }, {
-                name: 'zoneMatchProp',
-                type: 'enum',
-                default: 'any',
-                description: 'Whether to match the value, label or both values of each selection option when filtering.',
-                allowedTypes: 'any, label, value'
-            }, {
-                name: 'zonePlaceholderText',
-                type: 'string',
-                default: '',
-                description: 'Set the placeholder text in the Time Zone Select component.',
-                allowedTypes: ''
-            }
-        ];
-
-        const customZoneOptions = [{"value":"Etc/GMT+12","label":"(UTC-12:00) International Date Line West"},{"value":"Etc/GMT+11","label":"(UTC-11:00) Coordinated Universal Time-11"},{"value":"Pacific/Honolulu","label":"(UTC-10:00) Hawaii"},{"value":"America/Anchorage","label":"(UTC-09:00) Alaska"},{"value":"America/Tijuana","label":"(UTC-08:00) Baja California"},{"value":"America/Los_Angeles","label":"(UTC-08:00) Pacific Time (US & Canada)"},{"value":"America/Phoenix","label":"(UTC-07:00) Arizona"},{"value":"America/Chihuahua","label":"(UTC-07:00) Chihuahua, La Paz, Mazatlan"},{"value":"America/Denver","label":"(UTC-07:00) Mountain Time (US & Canada)"},{"value":"America/Guatemala","label":"(UTC-06:00) Central America"},{"value":"America/Chicago","label":"(UTC-06:00) Central Time (US & Canada)"},{"value":"America/Mexico_City","label":"(UTC-06:00) Guadalajara, Mexico City, Monterrey"},{"value":"America/Regina","label":"(UTC-06:00) Saskatchewan"},{"value":"America/Bogota","label":"(UTC-05:00) Bogota, Lima, Quito, Rio Branco"},{"value":"America/Cancun","label":"(UTC-05:00) Chetumal"},{"value":"America/New_York","label":"(UTC-05:00) Eastern Time (US & Canada)"},{"value":"America/Indianapolis","label":"(UTC-05:00) Indiana (East)"},{"value":"America/Caracas","label":"(UTC-04:30) Caracas"},{"value":"America/Asuncion","label":"(UTC-04:00) Asuncion"},{"value":"America/Halifax","label":"(UTC-04:00) Atlantic Time (Canada)"},{"value":"America/Cuiaba","label":"(UTC-04:00) Cuiaba"},{"value":"America/La_Paz","label":"(UTC-04:00) Georgetown, La Paz, Manaus, San Juan"},{"value":"America/St_Johns","label":"(UTC-03:30) Newfoundland"},{"value":"America/Sao_Paulo","label":"(UTC-03:00) Brasilia"},{"value":"America/Argentina/Buenos_Aires","label":"(UTC-03:00) Buenos Aires"},{"value":"America/Cayenne","label":"(UTC-03:00) Cayenne, Fortaleza"},{"value":"America/Godthab","label":"(UTC-03:00) Greenland"},{"value":"America/Montevideo","label":"(UTC-03:00) Montevideo"},{"value":"America/Bahia","label":"(UTC-03:00) Salvador"},{"value":"America/Santiago","label":"(UTC-03:00) Santiago"},{"value":"Etc/GMT+2","label":"(UTC-02:00) Coordinated Universal Time-02"},{"value":"Atlantic/Azores","label":"(UTC-01:00) Azores"},{"value":"Atlantic/Cape_Verde","label":"(UTC-01:00) Cabo Verde Is."},{"value":"Europe/London","label":"(UTC) Dublin, Edinburgh, Lisbon, London"},{"value":"Atlantic/Reykjavik","label":"(UTC) Monrovia, Reykjavik"},{"value":"Etc/GMT","label":"UTC"},{"value":"Africa/Casablanca","label":"(UTC) Casablanca"},{"value":"Europe/Berlin","label":"(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"},{"value":"Europe/Budapest","label":"(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague"},{"value":"Europe/Paris","label":"(UTC+01:00) Brussels, Copenhagen, Madrid, Paris"},{"value":"Europe/Warsaw","label":"(UTC+01:00) Sarajevo, Skopje, Warsaw, Zagreb"},{"value":"Africa/Lagos","label":"(UTC+01:00) West Central Africa"},{"value":"Africa/Windhoek","label":"(UTC+01:00) Windhoek"},{"value":"Asia/Amman","label":"(UTC+02:00) Amman"},{"value":"Europe/Bucharest","label":"(UTC+02:00) Athens, Bucharest"},{"value":"Asia/Beirut","label":"(UTC+02:00) Beirut"},{"value":"Africa/Cairo","label":"(UTC+02:00) Cairo"},{"value":"Asia/Damascus","label":"(UTC+02:00) Damascus"},{"value":"Europe/Chisinau","label":"(UTC+02:00) E. Europe"},{"value":"Africa/Johannesburg","label":"(UTC+02:00) Harare, Pretoria"},{"value":"Europe/Kiev","label":"(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius"},{"value":"Europe/Istanbul","label":"(UTC+02:00) Istanbul"},{"value":"Asia/Jerusalem","label":"(UTC+02:00) Jerusalem"},{"value":"Europe/Kaliningrad","label":"(UTC+02:00) Kaliningrad (RTZ 1)"},{"value":"Africa/Tripoli","label":"(UTC+02:00) Tripoli"},{"value":"Asia/Baghdad","label":"(UTC+03:00) Baghdad"},{"value":"Asia/Riyadh","label":"(UTC+03:00) Kuwait, Riyadh"},{"value":"Europe/Minsk","label":"(UTC+03:00) Minsk"},{"value":"Europe/Moscow","label":"(UTC+03:00) Moscow, St. Petersburg, Volgograd (RTZ 2)"},{"value":"Africa/Nairobi","label":"(UTC+03:00) Nairobi"},{"value":"Asia/Tehran","label":"(UTC+03:30) Tehran"},{"value":"Asia/Dubai","label":"(UTC+04:00) Abu Dhabi, Muscat"},{"value":"Asia/Baku","label":"(UTC+04:00) Baku"},{"value":"Europe/Samara","label":"(UTC+04:00) Izhevsk, Samara (RTZ 3)"},{"value":"Indian/Mauritius","label":"(UTC+04:00) Port Louis"},{"value":"Asia/Tbilisi","label":"(UTC+04:00) Tbilisi"},{"value":"Asia/Yerevan","label":"(UTC+04:00) Yerevan"},{"value":"Asia/Kabul","label":"(UTC+04:30) Kabul"},{"value":"Asia/Tashkent","label":"(UTC+05:00) Ashgabat, Tashkent"},{"value":"Asia/Yekaterinburg","label":"(UTC+05:00) Ekaterinburg (RTZ 4)"},{"value":"Asia/Karachi","label":"(UTC+05:00) Islamabad, Karachi"},{"value":"Asia/Kolkata","label":"(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi"},{"value":"Asia/Colombo","label":"(UTC+05:30) Sri Jayawardenepura"},{"value":"Asia/Katmandu","label":"(UTC+05:45) Kathmandu"},{"value":"Asia/Almaty","label":"(UTC+06:00) Astana"},{"value":"Asia/Dhaka","label":"(UTC+06:00) Dhaka"},{"value":"Asia/Novosibirsk","label":"(UTC+06:00) Novosibirsk (RTZ 5)"},{"value":"Asia/Rangoon","label":"(UTC+06:30) Yangon (Rangoon)"},{"value":"Asia/Bangkok","label":"(UTC+07:00) Bangkok, Hanoi, Jakarta"},{"value":"Asia/Krasnoyarsk","label":"(UTC+07:00) Krasnoyarsk (RTZ 6)"},{"value":"Asia/Shanghai","label":"(UTC+08:00) Beijing, Chongqing, Urumqi"},{"value":"Asia/Hong_Kong","label":"(UTC+08:00) Hong Kong"},{"value":"Asia/Irkutsk","label":"(UTC+08:00) Irkutsk (RTZ 7)"},{"value":"Asia/Singapore","label":"(UTC+08:00) Kuala Lumpur, Singapore"},{"value":"Asia/Manila","label":"(UTC+08:00) Manila (Philippines)"},{"value":"Australia/Perth","label":"(UTC+08:00) Perth"},{"value":"Asia/Taipei","label":"(UTC+08:00) Taipei"},{"value":"Asia/Ulaanbaatar","label":"(UTC+08:00) Ulaanbaatar"},{"value":"Asia/Tokyo","label":"(UTC+09:00) Osaka, Sapporo, Tokyo"},{"value":"Asia/Seoul","label":"(UTC+09:00) Seoul"},{"value":"Asia/Yakutsk","label":"(UTC+09:00) Yakutsk (RTZ 8)"},{"value":"Australia/Adelaide","label":"(UTC+09:30) Adelaide"},{"value":"Australia/Darwin","label":"(UTC+09:30) Darwin"},{"value":"Australia/Brisbane","label":"(UTC+10:00) Brisbane"},{"value":"Australia/Sydney","label":"(UTC+10:00) Canberra, Melbourne, Sydney"},{"value":"Pacific/Port_Moresby","label":"(UTC+10:00) Guam, Port Moresby"},{"value":"Australia/Hobart","label":"(UTC+10:00) Hobart"},{"value":"Asia/Magadan","label":"(UTC+10:00) Magadan"},{"value":"Asia/Vladivostok","label":"(UTC+10:00) Vladivostok, Magadan (RTZ 9)"},{"value":"Asia/Srednekolymsk","label":"(UTC+11:00) Chokurdakh (RTZ 10)"},{"value":"Pacific/Guadalcanal","label":"(UTC+11:00) Solomon Is., New Caledonia"},{"value":"Asia/Kamchatka","label":"(UTC+12:00) Anadyr, Petropavlovsk-Kamchatsky (RTZ 11)"},{"value":"Pacific/Auckland","label":"(UTC+12:00) Auckland, Wellington"},{"value":"Etc/GMT-12","label":"(UTC+12:00) Coordinated Universal Time+12"},{"value":"Pacific/Fiji","label":"(UTC+12:00) Fiji"},{"value":"Pacific/Tongatapu","label":"(UTC+13:00) Nuku'alofa"},{"value":"Pacific/Apia","label":"(UTC+13:00) Samoa"},{"value":"Pacific/Kiritimati","label":"(UTC+14:00) Kiritimati Island"}];
-
-        return (
-            <Main page="headers">
-                <Main.Content>
-                    <Card>
-                        <Header size="large">Props</Header>
-
-                        <TableProps props={props} />
-                    </Card>
-
-                    {/* Time Picker */}
-                    <Header size="large" style={{ marginTop: '55px' }} sub>
-                        Time Picker
-                        <Header.Subheader>
-                            A basic Time Picker.
-                        </Header.Subheader>
-                    </Header>
-
-                    <TimePicker
-                        id="foo_time_picker"
-                        onChange={this._onTimePickerChange.bind(this)}
-                        value={this.state.value}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {timePickerSample}
-                    </Highlighter>
-
-                    {/* Disable */}
-                    <Header size="large" style={{ marginTop: '55px' }} sub>
-                        Disable
-                        <Header.Subheader>
-                            Indicates that the Time Picker is not available for interaction.
-                        </Header.Subheader>
-                    </Header>
-
-                    <TimePicker
-                        disable
-                        onChange={this._onTimePickerChange.bind(this)}
-                        value={this.state.value}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {disableSample}
-                    </Highlighter>
-
-                    {/* Nest */}
-                    <Header size="large" style={{ marginTop: '55px' }} sub>
-                        Nest
-                        <Header.Subheader>
-                            A Time Picker can give the appearance of being nested. The parent's background color needs to be set to <code>color(backgroundColorNest)</code>.
-                        </Header.Subheader>
-                    </Header>
-
-                    <Block
-                        nest
-                        style={{ height: '175px', padding: '22px' }}
-                    >
-                        <TimePicker
-                            nest
-                            onChange={this._onNestChange.bind(this)}
-                            value={this.state.nestValue}
-                        />
-                    </Block>
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {nestSample}
-                    </Highlighter>
-
-                    {/* Range */}
-                    <Header size="large" style={{ marginTop: '55px' }} sub>
-                        Range
-                        <Header.Subheader>
-                            A Time Picker can be used in range mode, specifing a start time and an end time for the range.
-                        </Header.Subheader>
-                    </Header>
-
-                    <Block
-                        nest
-                        style={{ height: '175px', padding: '22px' }}
-                    >
-                        <TimePicker
-                            onChange={this._onRangeChange.bind(this)}
-                            range
-                            value={this.state.rangeValue}
-                        />
-                    </Block>
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {rangeSample}
-                    </Highlighter>
-
-                    {/* Zone Options */}
-                    <Header size="large" style={{ marginTop: '55px' }} sub>
-                        Zone Options
-                        <Header.Subheader>
-                            Provide a custom list of timezones to the Time Picker.
-                        </Header.Subheader>
-                    </Header>
-
-                    <TimePicker
-                        onChange={this._onTimePickerChange.bind(this)}
-                        value={this.state.value}
-                        zoneOptions={customZoneOptions}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {zoneOptionsSample}
-                    </Highlighter>
-
-                    {/* Zone Match Props */}
-                    <Header size="large" style={{ marginTop: '55px' }} sub>
-                        Zone Match Props
-                        <Header.Subheader>
-                            Whether to match the value, label or both values of each selection option when filtering.
-                        </Header.Subheader>
-                    </Header>
-
-                    <TimePicker
-                        onChange={this._onTimePickerChange.bind(this)}
-                        value={this.state.value}
-                        zoneOptions={customZoneOptions}
-                        zoneMatchProp="label"
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {zoneMatchPropSample}
-                    </Highlighter>
-                </Main.Content>
-            </Main>
-        );
-    }
-
-    _onTimePickerChange(value) {
-        this.setState({ value: value });
-    }
-
-    _onNestChange(value) {
-        this.setState({ nestValue: value });
-    }
-
-    _onRangeChange(value) {
-        this.setState({ rangeValue: value });
-    }
-
+            </Main.Content>
+        </Main>
+    );
 }
+
+DocsTimePicker.propTypes = propTypes;
+
+export default DocsTimePicker;

--- a/src/inputs/timePicker/timePicker.jsx
+++ b/src/inputs/timePicker/timePicker.jsx
@@ -18,9 +18,9 @@ import ClassNames from 'classnames';
 import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Dropdown from '../dropdown/dropdown';
 import Icon from '../../dataDisplay/icon';
 import Input from '../input';
+import Select from '../select/select';
 
 const propTypes = {
     className: PropTypes.string,
@@ -459,17 +459,16 @@ class TimePicker extends React.Component {
                 />
 
                 {showTimezone && (
-                    <Dropdown
+                    <Select
                         className="time-picker-zone-dropdown"
                         clearable={false}
                         disable={disable}
                         id={id ? `${id}-zone_dropdown` : null}
+                        matchProp={zoneMatchProp || 'label'}
+                        menuMaxHeight={448}
                         onChange={this.onZoneDropdownChange}
                         options={zoneOptions}
                         placeholder={zonePlaceholderText || 'Select a Time Zone'}
-                        selection
-                        selectionMatchProp={zoneMatchProp || 'label'}
-                        menuMaxHeight={448}
                         tabIndex={0}
                         value={value.timeZone}
                     />
@@ -485,14 +484,13 @@ class TimePicker extends React.Component {
                         {/* eslint-enable jsx-a11y/label-has-associated-control */}
 
                         <div>
-                            <Dropdown
+                            <Select
                                 clearable={false}
                                 id={id ? `${id}-hour_dropdown` : null}
+                                menuMaxHeight={448}
                                 onChange={this.onTimeHourDropdownChange}
                                 options={hourOptions}
                                 placeholder="hh"
-                                selection
-                                menuMaxHeight={448}
                                 style={{
                                     minWidth: 72,
                                 }}
@@ -502,15 +500,14 @@ class TimePicker extends React.Component {
 
                             <span className="colon">:</span>
 
-                            <Dropdown
+                            <Select
                                 clearable={false}
+                                creatable
                                 id={id ? `${id}-minute_dropdown` : null}
+                                menuMaxHeight={448}
                                 onChange={this.onTimeMinuteDropdownChange}
                                 options={minuteOptions}
                                 placeholder="mm"
-                                selection
-                                menuMaxHeight={448}
-                                selectionCreatable
                                 style={{
                                     minWidth: 72,
                                 }}
@@ -518,14 +515,13 @@ class TimePicker extends React.Component {
                                 value={minuteFromDropdownValue}
                             />
 
-                            <Dropdown
+                            <Select
                                 clearable={false}
                                 id={id ? `${id}-period_dropdown` : null}
+                                menuMaxHeight={448}
                                 onChange={this.onTimePeriodDropdownChange}
                                 options={periodOptions}
                                 placeholder="AM"
-                                selection
-                                menuMaxHeight={448}
                                 style={{
                                     minWidth: 72,
                                 }}
@@ -540,14 +536,13 @@ class TimePicker extends React.Component {
 
                         {range && (
                             <div>
-                                <Dropdown
+                                <Select
                                     clearable={false}
                                     id={id ? `${id}-hour_to_dropdown` : null}
+                                    menuMaxHeight={448}
                                     onChange={this.onTimeHourToDropdownChange}
                                     options={hourOptions}
                                     placeholder="hh"
-                                    selection
-                                    menuMaxHeight={448}
                                     style={{
                                         minWidth: 72,
                                     }}
@@ -557,15 +552,14 @@ class TimePicker extends React.Component {
 
                                 <span className="colon">:</span>
 
-                                <Dropdown
+                                <Select
                                     clearable={false}
+                                    creatable
                                     id={id ? `${id}-minute_to_dropdown` : null}
+                                    menuMaxHeight={448}
                                     onChange={this.onTimeMinuteToDropdownChange}
                                     options={minuteOptions}
                                     placeholder="mm"
-                                    selection
-                                    menuMaxHeight={448}
-                                    selectionCreatable
                                     style={{
                                         minWidth: 72,
                                     }}
@@ -573,14 +567,13 @@ class TimePicker extends React.Component {
                                     value={minuteToDropdownValue}
                                 />
 
-                                <Dropdown
+                                <Select
                                     clearable={false}
                                     id={id ? `${id}-period_to_dropdown` : null}
+                                    menuMaxHeight={448}
                                     onChange={this.onTimePeriodToDropdownChange}
                                     options={periodOptions}
                                     placeholder="PM"
-                                    selection
-                                    menuMaxHeight={448}
                                     style={{
                                         minWidth: 72,
                                     }}

--- a/src/inputs/timePicker/timePicker.jsx
+++ b/src/inputs/timePicker/timePicker.jsx
@@ -450,7 +450,7 @@ class TimePicker extends React.Component {
                     onKeyDown={this.onInputKeyDown}
                     placeholder={range ? 'hh:mm AM - hh:mm PM' : 'hh:mm AM'}
                     required={required}
-                    tabIndex={1}
+                    tabIndex={0}
                     value={value && value.timeDisplay ? value.timeDisplay : null}
                 />
 
@@ -490,7 +490,7 @@ class TimePicker extends React.Component {
                                 style={{
                                     minWidth: 72,
                                 }}
-                                tabIndex={2}
+                                tabIndex={0}
                                 value={hourFromDropdownValue}
                             />
 
@@ -508,7 +508,7 @@ class TimePicker extends React.Component {
                                 style={{
                                     minWidth: 72,
                                 }}
-                                tabIndex={3}
+                                tabIndex={0}
                                 value={minuteFromDropdownValue}
                             />
 
@@ -523,7 +523,7 @@ class TimePicker extends React.Component {
                                 style={{
                                     minWidth: 72,
                                 }}
-                                tabIndex={4}
+                                tabIndex={0}
                                 value={periodFromDropdownValue}
                             />
                         </div>
@@ -545,7 +545,7 @@ class TimePicker extends React.Component {
                                     style={{
                                         minWidth: 72,
                                     }}
-                                    tabIndex={2}
+                                    tabIndex={0}
                                     value={hourToDropdownValue}
                                 />
 
@@ -563,7 +563,7 @@ class TimePicker extends React.Component {
                                     style={{
                                         minWidth: 72,
                                     }}
-                                    tabIndex={3}
+                                    tabIndex={0}
                                     value={minuteToDropdownValue}
                                 />
 
@@ -578,7 +578,7 @@ class TimePicker extends React.Component {
                                     style={{
                                         minWidth: 72,
                                     }}
-                                    tabIndex={4}
+                                    tabIndex={0}
                                     value={periodToDropdownValue}
                                 />
                             </div>

--- a/src/inputs/timePicker/timePicker.jsx
+++ b/src/inputs/timePicker/timePicker.jsx
@@ -35,6 +35,7 @@ const propTypes = {
     onChange: PropTypes.func,
     range: PropTypes.bool,
     required: PropTypes.bool,
+    showTimezone: PropTypes.bool,
     style: PropTypes.shape({}),
     value: PropTypes.shape({
         timeDisplay: PropTypes.string,
@@ -60,6 +61,7 @@ const defaultProps = {
     onChange: undefined,
     range: false,
     required: false,
+    showTimezone: true,
     style: undefined,
     value: undefined,
     zoneMatchProp: 'label',
@@ -355,6 +357,7 @@ class TimePicker extends React.Component {
             nest,
             range,
             required,
+            showTimezone,
             style,
             zoneMatchProp,
             zonePlaceholderText,
@@ -438,6 +441,7 @@ class TimePicker extends React.Component {
                         <Icon
                             color={isTimePopoverActive ? 'highlight' : null}
                             compact
+                            title="Show Time Picker"
                             type="time"
                             onClick={this.onTimePopoverToggle}
                         />
@@ -454,20 +458,22 @@ class TimePicker extends React.Component {
                     value={value && value.timeDisplay ? value.timeDisplay : null}
                 />
 
-                <Dropdown
-                    className="time-picker-zone-dropdown"
-                    clearable={false}
-                    disable={disable}
-                    id={id ? `${id}-zone_dropdown` : null}
-                    onChange={this.onZoneDropdownChange}
-                    options={zoneOptions}
-                    placeholder={zonePlaceholderText || 'Select a Time Zone'}
-                    selection
-                    selectionMatchProp={zoneMatchProp || 'label'}
-                    menuMaxHeight={448}
-                    tabIndex={isTimePopoverActive ? 5 : 2}
-                    value={value.timeZone}
-                />
+                {showTimezone && (
+                    <Dropdown
+                        className="time-picker-zone-dropdown"
+                        clearable={false}
+                        disable={disable}
+                        id={id ? `${id}-zone_dropdown` : null}
+                        onChange={this.onZoneDropdownChange}
+                        options={zoneOptions}
+                        placeholder={zonePlaceholderText || 'Select a Time Zone'}
+                        selection
+                        selectionMatchProp={zoneMatchProp || 'label'}
+                        menuMaxHeight={448}
+                        tabIndex={0}
+                        value={value.timeZone}
+                    />
+                )}
 
                 {isTimePopoverActive ? (
                     <div

--- a/src/inputs/timePicker/timePicker.scss
+++ b/src/inputs/timePicker/timePicker.scss
@@ -20,7 +20,7 @@
         top: 64px;
         width: 260px;
         z-index: 1;
-        .ui.dropdown.dropdown-selection { margin-top: 0; }
+        .cmui.select { margin-top: 0; }
         > div {
             align-items: center;
             display: flex;

--- a/src/inputs/timePicker/timePickerCreatableOption.jsx
+++ b/src/inputs/timePicker/timePickerCreatableOption.jsx
@@ -1,0 +1,49 @@
+import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const propTypes = {
+    onFocus: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
+    option: PropTypes.shape({
+        label: PropTypes.string,
+    }).isRequired,
+};
+
+// NOTE: Not a function component because of stupid React Select trying to
+//       assign a ref to it and this generates a console warning :-(
+class CreatableOptionComponent extends React.PureComponent {
+    render() {
+        const {
+            onFocus,
+            onSelect,
+            option,
+        } = this.props;
+
+        return (
+            <div
+                className="Select-option"
+                key={option.label}
+                onClick={() => onSelect(option)}
+                onFocus={noop}
+                onKeyDown={noop}
+                onMouseOver={() => onFocus(option)}
+                role="option"
+                aria-selected="true"
+                tabIndex={0}
+                style={{
+                    display: 'flex',
+                }}
+            >
+                <span>
+                    {option.label}
+                </span>
+            </div>
+        );
+    }
+}
+
+CreatableOptionComponent.propTypes = propTypes;
+CreatableOptionComponent.displayName = 'TimePickerCreatableOptionComponent';
+
+export default CreatableOptionComponent;

--- a/src/versions.js
+++ b/src/versions.js
@@ -48,6 +48,11 @@ const versions = {
                     designLibraryVersion: '2.0.0',
                     designLibraryDoc: 'https://www.sketch.com/s/6c8808fa-bf58-42e5-a0be-7e9d5798fc5f/p/45DC2CF5-702E-4572-9EDF-D952D3A22727',
                 },
+                timePicker: {
+                    devLibraryVersion: '???',
+                    designLibraryVersion: '???',
+                    // designLibraryDoc: '???',
+                },
             },
             layout: {
                 grid: {

--- a/src/versions.js
+++ b/src/versions.js
@@ -49,9 +49,9 @@ const versions = {
                     designLibraryDoc: 'https://www.sketch.com/s/6c8808fa-bf58-42e5-a0be-7e9d5798fc5f/p/45DC2CF5-702E-4572-9EDF-D952D3A22727',
                 },
                 timePicker: {
-                    devLibraryVersion: '???',
-                    designLibraryVersion: '???',
-                    // designLibraryDoc: '???',
+                    devLibraryVersion: '2.0.0',
+                    designLibraryVersion: 'N/A',
+                    designLibraryDoc: 'N/A',
                 },
             },
             layout: {


### PR DESCRIPTION
**Main functional change:**

Add prop `showTimezone` (optional; defaults to `true`) to `TimePicker` component to be able to optionally suppress the Time Zone Select.  Done in service of PBI [AB#25925](https://dev.azure.com/saddlebackchurch/b8a0d0bb-a4fe-48e3-9a60-2f1440145fc4/_workitems/edit/25925) because we need a time of day selector in the filters rail for Connection Forms 2.0 entries but not a Time Zone selector (no comp of this, but it's in the [requirements](https://saddleback.egnyte.com/navigate/file/ca010ee4-562d-4e56-b9e0-01e6c46d207f) (see [V.2]).

**Other Enhancements:**
* Cleanup ESLINT issues in `TimePicker` component source file
* Replace `Dropdown` controls with `Select` controls in `TimePicker` component
* Try to improve the behavior where the popover closes when you're only partially done (due to `onClickOutside` handler)
* Modernize the documentation for the `TimePicker`

![image](https://user-images.githubusercontent.com/4349658/129070453-273cf969-adeb-4cce-9697-daa5c93b1264.png)
