### PR TITLE
[dev] AB#25926 - [W.2] - Ability to create an entry for a connection form - Modification of default props on person panel react-cm-ui component 

### DIFF
--- a/src/dataDisplay/personPanel/personPanelDetails.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetails.jsx
@@ -200,7 +200,10 @@ const defaultProps = {
     isExpanded: false,
     isMobile: false,
     otherDataGroups: null,
-    selectButtonProps: {},
+    selectButtonProps: {
+        label: 'Select',
+        disable: false,
+    },
     showSelectButton: true,
     viewRecordButtonProps: {},
 };

--- a/src/dataDisplay/personPanel/personPanelDetails.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetails.jsx
@@ -173,6 +173,10 @@ const propTypes = {
         promptId: PropTypes.string,
     }),
     /**
+     * If `false`, select button isn't displayed for PersonPanelDetails.
+     */
+    showSelectButton: PropTypes.bool,
+    /**
      * Button `props` to setup the View Record button.
      */
     viewRecordButtonProps: PropTypes.shape({
@@ -197,6 +201,7 @@ const defaultProps = {
     isMobile: false,
     otherDataGroups: null,
     selectButtonProps: {},
+    showSelectButton: true,
     viewRecordButtonProps: {},
 };
 
@@ -664,6 +669,7 @@ function PersonPanelDetails(props) {
         isMobile,
         otherDataGroups,
         selectButtonProps,
+        showSelectButton,
         viewRecordButtonProps,
     } = props;
 
@@ -888,28 +894,31 @@ function PersonPanelDetails(props) {
 
                     {children}
 
-                    {(!isEmpty(selectButtonProps) || !isEmpty(viewRecordButtonProps)) && (
-                        <div
-                            className={classes.actions}
-                        >
-                            {!isEmpty(selectButtonProps) && (
-                                <PersonPanelDetailsActionButton
-                                    label="Select"
-                                    // eslint-disable-next-line react/jsx-props-no-spreading
-                                    {...selectButtonProps}
-                                />
-                            )}
+                    {
+                        ((!isEmpty(selectButtonProps) && showSelectButton) ||
+                        !isEmpty(viewRecordButtonProps)) && (
+                            <div
+                                className={classes.actions}
+                            >
+                                {!isEmpty(selectButtonProps) && showSelectButton && (
+                                    <PersonPanelDetailsActionButton
+                                        label="Select"
+                                        // eslint-disable-next-line react/jsx-props-no-spreading
+                                        {...selectButtonProps}
+                                    />
+                                )}
 
-                            {!isEmpty(viewRecordButtonProps) && (
-                                <PersonPanelDetailsActionButton
-                                    // eslint-disable-next-line react/jsx-props-no-spreading
-                                    {...viewRecordButtonProps}
-                                    label="View Record"
-                                    outlined
-                                />
-                            )}
-                        </div>
-                    )}
+                                {!isEmpty(viewRecordButtonProps) && (
+                                    <PersonPanelDetailsActionButton
+                                        // eslint-disable-next-line react/jsx-props-no-spreading
+                                        {...viewRecordButtonProps}
+                                        label="View Record"
+                                        outlined
+                                    />
+                                )}
+                            </div>
+                        )
+                    }
                 </div>
             </Collapse>
         </div>

--- a/src/dataDisplay/personPanel/personPanelDetails.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetails.jsx
@@ -196,10 +196,7 @@ const defaultProps = {
     isExpanded: false,
     isMobile: false,
     otherDataGroups: null,
-    selectButtonProps: {
-        label: 'Select',
-        disable: false,
-    },
+    selectButtonProps: {},
     viewRecordButtonProps: {},
 };
 

--- a/src/dataDisplay/personPanel/personPanelDetails.jsx
+++ b/src/dataDisplay/personPanel/personPanelDetails.jsx
@@ -836,6 +836,8 @@ function PersonPanelDetails(props) {
     );
 
     const shouldDataGroupsRender = !isEmpty(data) && !isEmpty(dataGroupsColumns);
+    const shouldRenderSelectButton = showSelectButton && !isEmpty(selectButtonProps);
+    const shouldRenderViewButton = !isEmpty(viewRecordButtonProps);
 
     return (
         <div
@@ -894,31 +896,28 @@ function PersonPanelDetails(props) {
 
                     {children}
 
-                    {
-                        ((!isEmpty(selectButtonProps) && showSelectButton) ||
-                        !isEmpty(viewRecordButtonProps)) && (
-                            <div
-                                className={classes.actions}
-                            >
-                                {!isEmpty(selectButtonProps) && showSelectButton && (
-                                    <PersonPanelDetailsActionButton
-                                        label="Select"
-                                        // eslint-disable-next-line react/jsx-props-no-spreading
-                                        {...selectButtonProps}
-                                    />
-                                )}
+                    {(shouldRenderSelectButton || shouldRenderViewButton) && (
+                        <div
+                            className={classes.actions}
+                        >
+                            {shouldRenderSelectButton && (
+                                <PersonPanelDetailsActionButton
+                                    label="Select"
+                                    // eslint-disable-next-line react/jsx-props-no-spreading
+                                    {...selectButtonProps}
+                                />
+                            )}
 
-                                {!isEmpty(viewRecordButtonProps) && (
-                                    <PersonPanelDetailsActionButton
-                                        // eslint-disable-next-line react/jsx-props-no-spreading
-                                        {...viewRecordButtonProps}
-                                        label="View Record"
-                                        outlined
-                                    />
-                                )}
-                            </div>
-                        )
-                    }
+                            {shouldRenderViewButton && (
+                                <PersonPanelDetailsActionButton
+                                    // eslint-disable-next-line react/jsx-props-no-spreading
+                                    {...viewRecordButtonProps}
+                                    label="View Record"
+                                    outlined
+                                />
+                            )}
+                        </div>
+                    )}
                 </div>
             </Collapse>
         </div>

--- a/src/dataDisplay/personPanel/personPanelSummary.jsx
+++ b/src/dataDisplay/personPanel/personPanelSummary.jsx
@@ -577,17 +577,19 @@ function PersonPanelSummary(props) {
                     </Grid.Column>
                 )}
 
-                <Grid.Column
-                    className={personIdColumnClasses}
-                    textAlign="right"
-                >
-                    <Typography
-                        className={classes.personId}
-                        variant="caption"
+                {personId && (
+                    <Grid.Column
+                        className={personIdColumnClasses}
+                        textAlign="right"
                     >
-                        {`Id: ${personId}`}
-                    </Typography>
-                </Grid.Column>
+                        <Typography
+                            className={classes.personId}
+                            variant="caption"
+                        >
+                            {`Id: ${personId}`}
+                        </Typography>
+                    </Grid.Column>
+                )}
             </Grid>
         </div>
     );


### PR DESCRIPTION
PR contains:
- Modification of default props for person panel component
- If `personId` isn't passed for `summaryData` then don't display personId

#note: @War777 I have been reverting some code which I believe was changed by you. Could you please verify it once?