### PR TITLE
[dev] No PBI - Fixing Image type prop (it was always rendering 'user').

### DIFF
--- a/src/dataDisplay/image/image.jsx
+++ b/src/dataDisplay/image/image.jsx
@@ -96,7 +96,7 @@ function Image(props) {
                     compact
                     size={avatarSize}
                     title="This person has no image"
-                    type="user"
+                    type={type}
                 />
             )}
         </ElementType>

--- a/src/dataDisplay/image/image.jsx
+++ b/src/dataDisplay/image/image.jsx
@@ -130,7 +130,7 @@ Image.defaultProps = {
     size: undefined,
     src: undefined,
     style: {},
-    type: undefined,
+    type: 'user',
 };
 
 export default Image;


### PR DESCRIPTION
This will allow us to render `<Image type="person" />` (It the image was always rendering the `user` icon).

**Before:**

![image](https://user-images.githubusercontent.com/8116485/140387248-4499622f-bebb-4c0f-bc7f-967fba9d39c3.png)

**After:**

![image](https://user-images.githubusercontent.com/8116485/140387684-bdce9d02-8d47-4455-9939-530bdfcb47d1.png)
