### PR TITLE
[dev] Related to AB#58900 DatePickerInput enhancements

### DIFF
--- a/docs/src/app/navigationConstants.js
+++ b/docs/src/app/navigationConstants.js
@@ -301,6 +301,18 @@ export const navigationItems = [
                         component: 'datePickerInput',
                         label: 'Date Picker Input',
                         path: 'date-picker-input',
+                        levelFour: [
+                            {
+                                component: 'devSandbox/index.js',
+                                label: 'Dev Sandbox',
+                                path: 'dev-sandbox',
+                            },
+                            {
+                                component: 'api/index.js',
+                                label: 'API',
+                                path: 'api',
+                            },
+                        ],
                     },
                     {
                         component: 'dropdownDeprecated',

--- a/docs/src/inputs/datePickerInput/api/api.jsx
+++ b/docs/src/inputs/datePickerInput/api/api.jsx
@@ -1,0 +1,29 @@
+import {
+    camelCase,
+} from 'lodash';
+import React from 'react';
+import ComponentApi from '../../../global/componentApi';
+import Main from '../../../global/main';
+/* eslint-disable import/no-named-default, import/extensions */
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/datePickerInput/datePickerInput';
+/* eslint-enable import/no-named-default, import/extensions */
+
+function DocsApi() {
+    const {
+        displayName,
+    } = rootDoc;
+
+    return (
+        <Main page={camelCase(displayName)}>
+            <Main.Content>
+                <ComponentApi
+                    docs={[
+                        rootDoc,
+                    ]}
+                />
+            </Main.Content>
+        </Main>
+    );
+}
+
+export default DocsApi;

--- a/docs/src/inputs/datePickerInput/api/index.js
+++ b/docs/src/inputs/datePickerInput/api/index.js
@@ -1,0 +1,1 @@
+export { default } from './api';

--- a/docs/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/docs/src/inputs/datePickerInput/datePickerInput.jsx
@@ -1,666 +1,74 @@
 import {
-    Card,
-    DatePickerInput,
-    Grid,
-    Header,
+    Typography,
 } from 'react-cm-ui';
+import {
+    camelCase,
+} from 'lodash';
+import { withRouter } from 'react-router';
 import moment from 'moment-timezone';
+import PropTypes from 'prop-types';
 import React from 'react';
-import Highlighter from '../../global/highlighter';
+import ComponentVersionIdentifier from '../../global/componentVersionIdentifier';
+import Example from '../../global/example';
+import ExampleDatePickerInputBasic from './examples/exampleDatePickerInputBasic';
+import Heading from '../../global/heading';
 import Main from '../../global/main';
-import TableProps from '../../global/tableProps';
+import MarkdownContainer from '../../global/markdownContainer';
+/* eslint-disable import/no-named-default, import/extensions */
+import { default as componentDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/datePickerInput/datePickerInput';
+/* eslint-enable import/no-named-default, import/extensions */
 
-const datePickerSample = `import { DatePickerInput } from 'react-cm-ui';
-import React from 'react';
+const propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string,
+    }).isRequired,
+};
 
-export default class DatePickerSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput />
-        );
-    }
-}`;
+function DocsDatePickerInput(props) {
+    const {
+        location: {
+            pathname,
+        },
+    } = props;
 
-const disabledSample = `import { DatePickerInput } from 'react-cm-ui';
-import React from 'react';
+    const {
+        description: componentDescription,
+        displayName: componentName,
+    } = componentDoc;
 
-export default class DisabledSample extends React.Component {
-    constructor() {
-        super();
+    return (
+        <Main page={camelCase(componentName)}>
+            <Main.Content>
+                <MarkdownContainer>
+                    <Typography
+                        className="description"
+                        variant="body1"
+                    >
+                        {componentDescription}
+                    </Typography>
 
-        this.state = {
-            dateOnChange: moment(),
-        };
+                    <Heading
+                        anchorLink="default-date-picker-input"
+                        variant="h2"
+                    >
+                        Default DatePickerInput
+                    </Heading>
+                </MarkdownContainer>
 
-        this.onChange = this.onChange.bind(this);
-    }
+                <Example
+                    rawCode={require('!!raw-loader!./examples/exampleDatePickerInputBasic').default}
+                >
+                    <ExampleDatePickerInputBasic />
+                </Example>
 
-    render() {
-        return (
-            <DatePickerInput
-                date={dateOnChange}
-                disable
-                onChange={this.onChange}
-            />
-        );
-    }
-
-    onChange({ date, dateFrom, dateTo }) {
-        this.setState({
-            dateOnChange: date,
-        });
-    }
-}`;
-
-const eventsSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class EventsSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                events={[
-                    moment().subtract(1, 'days'),
-                    moment().subtract(2, 'days'),
-                    moment().subtract(3, 'days'),
-                    moment().subtract(4, 'days'),
-                ]}
-            />
-        );
-    }
-}`;
-
-const excludeDatesSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class ExcludeDatesSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                excludeDates={[
-                    moment().subtract(1, 'days'),
-                    moment().subtract(2, 'days'),
-                    moment().subtract(3, 'days'),
-                    moment().subtract(4, 'days'),
-                ]}
-            />
-        );
-    }
-}`;
-
-const filterDatesSample = `import { DatePickerInput } from 'react-cm-ui';
-import React from 'react';
-
-export default class FilterDatesSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                filterDates={this.isWeekend}
-            />
-        );
-    }
-
-    isWeekend(date) {
-        const day = date.day();
-
-        return day === 0 || day === 6;
-    }
-}`;
-
-const includeDatesSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class IncludeDatesSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                includeDates={[
-                    moment(),
-                    moment().subtract(1, 'days'),
-                ]}
-            />
-        );
-    }
-}`;
-
-const labelSample = `import { DatePickerInput } from 'react-cm-ui';
-import React from 'react';
-
-export default class LabelSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput label="The Coolest Label Ever"/>
-        );
-    }
-}`;
-
-const localeSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class LocaleSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                locale={moment().locale()}
-            />
-        );
-    }
-}`;
-
-const maxDateSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class MaxDateSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                maxDate={moment()}
-            />
-        );
-    }
-}`;
-
-const minDateSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class MinDateSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                minDate={moment().subtract(10, 'years')}
-            />
-        );
-    }
-}`;
-
-const onChangeSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class OnChangeSample extends React.Component {
-    constructor() {
-        super();
-
-        this.state = {
-            dateOnChange: moment(),
-        };
-
-        this.onChange = this.onChange.bind(this);
-    }
-
-    render() {
-        return (
-            <DatePickerInput
-                date={dateOnChange}
-                onChange={this.onChange}
-            />
-        );
-    }
-
-    onChange({ date, dateFrom, dateTo }) {
-        this.setState({
-            dateOnChange: date,
-        });
-    }
-}`;
-
-const onMonthChangeSample = `import { DatePickerInput } from 'react-cm-ui';
-import React from 'react';
-
-export default class OnMonthChangeSample extends React.Component {
-    render() {
-        return (
-            <DatePickerInput
-                onMonthChange={() => window.alert('The month was changed!') }
-            />
-        );
-    }
-}`;
-
-const rangeSample = `import { DatePickerInput } from 'react-cm-ui';
-import moment from 'moment-timezone';
-import React from 'react';
-
-export default class RangeSample extends React.Component {
-    constructor() {
-        super();
-
-        this.state = {
-            dateRangeFrom: moment(),
-            dateRangeTo: moment(),
-        };
-
-        this.onRangeChange = this.onRangeChange.bind(this);
-    }
-
-    render() {
-        return (
-            <div>
-                <DatePickerInput
-                    dateFrom={dateRangeFrom}
-                    dateTo={dateRangeTo}
-                    onChange={this.onRangeChange}
-                    rangeFrom
-                    label="From"
+                <ComponentVersionIdentifier
+                    pathname={pathname}
                 />
-                <DatePickerInput
-                    dateFrom={dateRangeFrom}
-                    dateTo={dateRangeTo}
-                    onChange={this.onRangeChange}
-                    rangeTo
-                    label="To"
-                />
-            </div>
-        );
-    }
-
-    onRangeChange({ date, dateFrom, dateTo }) {
-        this.setState({
-            dateRangeFrom: dateFrom,
-            dateRangeTo: dateTo,
-        });
-    }
-}`;
-
-export default class ModulesDatePickerInput extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            caledarDate: {},
-            dateOnChange: moment(),
-            dateRangeFrom: moment(),
-            dateRangeTo: moment(),
-            inputDate: {},
-        };
-
-        this.isWeekend = this.isWeekend.bind(this);
-        this.onChange = this.onChange.bind(this);
-        this.onRangeChange = this.onRangeChange.bind(this);
-    }
-
-    onChange({ date }) {
-        this.setState({
-            dateOnChange: date,
-        });
-    }
-
-    onRangeChange({ dateFrom, dateTo }) {
-        this.setState({
-            dateRangeFrom: dateFrom,
-            dateRangeTo: dateTo,
-        });
-    }
-
-    isWeekend(date) {
-        const day = date.day();
-
-        return day === 0 || day === 6;
-    }
-
-    render() {
-        const props = [
-            {
-                name: 'className',
-                type: 'string',
-                default: '',
-                description: 'Additional classes.',
-                allowedTypes: '',
-            }, {
-                name: 'date',
-                type: 'object',
-                default: '',
-                description: 'Single date timestamp.',
-                allowedTypes: '',
-            }, {
-                name: 'dateFrom',
-                type: 'object',
-                default: '',
-                description: 'Moment object for date range',
-                allowedTypes: '',
-            }, {
-                name: 'dateTo',
-                type: 'object',
-                default: '',
-                description: 'Moment object for date range',
-                allowedTypes: '',
-            }, {
-                name: 'disable',
-                type: 'bool',
-                default: '',
-                description: 'Indicates that the date input is not available for interaction.',
-                allowedTypes: '',
-            }, {
-                name: 'events',
-                type: 'array',
-                default: '',
-                description: 'Accepts an array of moment objects.',
-                allowedTypes: '',
-            }, {
-                name: 'excludeDates',
-                type: 'array',
-                default: '',
-                description: 'Sets a range of dates that are not selectable.',
-                allowedTypes: '',
-            }, {
-                name: 'filterDates',
-                type: 'func',
-                default: '',
-                description: 'Filters out dates that are to not be selectable.',
-                allowedTypes: '',
-            }, {
-                name: 'id',
-                type: 'string',
-                default: '',
-                description: 'Give an input an id.',
-                allowedTypes: '',
-            }, {
-                name: 'includeDates',
-                type: 'array',
-                default: '',
-                description: 'Sets a range of dates that are selectable.',
-                allowedTypes: '',
-            }, {
-                name: 'label',
-                type: 'string',
-                default: '',
-                description: 'Optional Label to display with the Input.',
-                allowedTypes: '',
-            }, {
-                name: 'locale',
-                type: 'string',
-                default: '',
-                description: 'Custom locale.',
-                allowedTypes: '',
-            }, {
-                name: 'maxDate',
-                type: 'object',
-                default: '',
-                description: 'Maxium date\'s in range that are selectable.',
-                allowedTypes: '',
-            }, {
-                name: 'minDate',
-                type: 'object',
-                default: '',
-                description: 'Minumum date\'s in range that are selectable.',
-                allowedTypes: '',
-            }, {
-                name: 'onBlur',
-                type: 'func',
-                default: '',
-                description: 'Can handle an onBlur event from parent.',
-                allowedTypes: '',
-            }, {
-                name: 'onChange',
-                type: 'func',
-                default: '',
-                description: 'Can handle an onChange event from parent.',
-                allowedTypes: '',
-            }, {
-                name: 'onFocus',
-                type: 'func',
-                default: '',
-                description: 'Can handle an onFocus event from parent.',
-                allowedTypes: '',
-            }, {
-                name: 'rangeFrom',
-                type: 'bool',
-                default: '',
-                description: 'Specifies whether the input is the from in the date range or not.',
-                allowedTypes: '',
-            }, {
-                name: 'rangeTo',
-                type: 'bool',
-                default: '',
-                description: 'Specifies whether the input is the to in the date range or not.',
-                allowedTypes: '',
-            }, {
-                name: 'required',
-                type: 'bool',
-                default: '',
-                description: 'Specifies that the user must fill in a value before submitting a form.',
-                allowedTypes: '',
-            }, {
-                name: 'style',
-                type: 'object',
-                default: '',
-                description: 'Supply any inline styles to the DatePickerInput\'s container. Mainly used for padding and margins.',
-                allowedTypes: '',
-            }, {
-                name: 'tabIndex',
-                type: 'number',
-                default: '',
-                description: 'An Input can receive focus.',
-                allowedTypes: '',
-            },
-        ];
-        const {
-            dateOnChange,
-            dateRangeFrom,
-            dateRangeTo,
-        } = this.state;
-
-        return (
-            <Main page="headers">
-                <Main.Content>
-                    <Card>
-                        <Header size="large">Props</Header>
-
-                        <TableProps props={props} />
-                    </Card>
-
-                    {/* Date Picker Input */}
-                    <Header anchor="date-picker-input" size="large" style={{ marginTop: '55px' }}>
-                        Date Picker Input
-                    </Header>
-
-                    <DatePickerInput />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {datePickerSample}
-                    </Highlighter>
-
-                    {/* Disable */}
-                    <Header anchor="disable" size="large" style={{ marginTop: '55px' }}>
-                        Disable
-                    </Header>
-
-                    <DatePickerInput
-                        date={dateOnChange}
-                        disable
-                        onChange={this.onChange}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {disabledSample}
-                    </Highlighter>
-
-                    {/* Events */}
-                    <Header anchor="events" size="large" style={{ marginTop: '55px' }}>
-                        Events
-                    </Header>
-
-                    <DatePickerInput
-                        events={[
-                            moment().subtract(1, 'days'),
-                            moment().subtract(2, 'days'),
-                            moment().subtract(3, 'days'),
-                            moment().subtract(4, 'days'),
-                        ]}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {eventsSample}
-                    </Highlighter>
-
-                    {/* Exclude Dates */}
-                    <Header anchor="exclude-dates" size="large" style={{ marginTop: '55px' }}>
-                        Exclude Dates
-                    </Header>
-
-                    <DatePickerInput
-                        excludeDates={[
-                            moment().subtract(1, 'days'),
-                            moment().subtract(2, 'days'),
-                            moment().subtract(3, 'days'),
-                            moment().subtract(4, 'days'),
-                        ]}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {excludeDatesSample}
-                    </Highlighter>
-
-                    {/* Filter Dates */}
-                    <Header anchor="filter-dates" size="large" style={{ marginTop: '55px' }}>
-                        Filter Dates
-                    </Header>
-
-                    <DatePickerInput
-                        filterDates={this.isWeekend}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {filterDatesSample}
-                    </Highlighter>
-
-                    {/* Include Dates */}
-                    <Header anchor="include-dates" size="large" style={{ marginTop: '55px' }}>
-                        Include Dates
-                    </Header>
-
-                    <DatePickerInput
-                        includeDates={[
-                            moment(),
-                            moment().subtract(1, 'days'),
-                        ]}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {includeDatesSample}
-                    </Highlighter>
-
-                    {/* Label */}
-                    <Header anchor="locale" size="large" style={{ marginTop: '55px' }}>
-                        Label
-                    </Header>
-
-                    <DatePickerInput label="The Coolest Label Ever"/>
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {labelSample}
-                    </Highlighter>
-
-                    {/* Locale */}
-                    <Header anchor="locale" size="large" style={{ marginTop: '55px' }}>
-                        Locale
-                    </Header>
-
-                    <DatePickerInput
-                        locale={moment().locale()}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {localeSample}
-                    </Highlighter>
-
-                    {/* Max Date */}
-                    <Header anchor="max-dates" size="large" style={{ marginTop: '55px' }}>
-                        Max Date
-                    </Header>
-
-                    <DatePickerInput
-                        maxDate={moment()}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {maxDateSample}
-                    </Highlighter>
-
-                    {/* Min Date */}
-                    <Header anchor="min-dates" size="large" style={{ marginTop: '55px' }}>
-                        Min Date
-                    </Header>
-
-                    <DatePickerInput
-                        minDate={moment().subtract(10, 'years')}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {minDateSample}
-                    </Highlighter>
-
-                    {/* onChange Event Handler */}
-                    <Header anchor="on-change" size="large" style={{ marginTop: '55px' }}>
-                        onChange Event Handler
-                    </Header>
-
-                    <DatePickerInput
-                        date={dateOnChange}
-                        onChange={this.onChange}
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {onChangeSample}
-                    </Highlighter>
-
-                    {/* onMonthChange */}
-                    <Header anchor="on-month-change" size="large" style={{ marginTop: '55px' }}>
-                        onMonthChange Event Handler
-                    </Header>
-
-                    <DatePickerInput
-                        onMonthChange={() => window.alert('The month was changed!') }
-                    />
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {onMonthChangeSample}
-                    </Highlighter>
-
-                    {/* Range */}
-                    <Header anchor="range" size="large" style={{ marginTop: '55px' }}>
-                        Range
-                    </Header>
-
-                    <Grid spacing={2}>
-                        <Grid.Column
-                            md="auto"
-                            sm={12}
-                        >
-                            <DatePickerInput
-                                dateFrom={dateRangeFrom}
-                                dateTo={dateRangeTo}
-                                onChange={this.onRangeChange}
-                                rangeFrom
-                                label="From"
-                            />
-                        </Grid.Column>
-
-                        <Grid.Column
-                            md="auto"
-                            sm={12}
-                        >
-                            <DatePickerInput
-                                dateFrom={dateRangeFrom}
-                                dateTo={dateRangeTo}
-                                onChange={this.onRangeChange}
-                                rangeTo
-                                label="To"
-                            />
-                        </Grid.Column>
-                    </Grid>
-
-                    <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                        {rangeSample}
-                    </Highlighter>
-                </Main.Content>
-            </Main>
-        );
-    }
+            </Main.Content>
+        </Main>
+    );
 }
+
+DocsDatePickerInput.propTypes = propTypes;
+
+export default withRouter(DocsDatePickerInput);

--- a/docs/src/inputs/datePickerInput/devSandbox/devSandbox.jsx
+++ b/docs/src/inputs/datePickerInput/devSandbox/devSandbox.jsx
@@ -1,0 +1,354 @@
+import {
+    Typography,
+} from 'react-cm-ui';
+import {
+    camelCase,
+} from 'lodash';
+import { withRouter } from 'react-router';
+import moment from 'moment-timezone';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Example from '../../../global/example';
+import ExampleDatePickerInputDisabled from '../examples/exampleDatePickerInputDisabled';
+import ExampleDatePickerInputEvents from '../examples/exampleDatePickerInputEvents';
+import ExampleDatePickerInputExcludeDates from '../examples/exampleDatePickerInputExcludeDates';
+import ExampleDatePickerInputFilterDates from '../examples/exampleDatePickerInputFilterDates';
+import ExampleDatePickerInputFluid from '../examples/exampleDatePickerInputFluid';
+import ExampleDatePickerInputIncludeDates from '../examples/exampleDatePickerInputIncludeDates';
+import ExampleDatePickerInputLabel from '../examples/exampleDatePickerInputLabel';
+import ExampleDatePickerInputLocale from '../examples/exampleDatePickerInputLocale';
+import ExampleDatePickerInputMaxDate from '../examples/exampleDatePickerInputMaxDate';
+import ExampleDatePickerInputMinDate from '../examples/exampleDatePickerInputMinDate';
+import ExampleDatePickerInputOnChange from '../examples/exampleDatePickerInputOnChange';
+import ExampleDatePickerInputOnMonthChange from '../examples/exampleDatePickerInputOnMonthChange';
+import ExampleDatePickerInputRange from '../examples/exampleDatePickerInputRange';
+import Heading from '../../../global/heading';
+import Main from '../../../global/main';
+import MarkdownContainer from '../../../global/markdownContainer';
+/* eslint-disable import/no-named-default, import/extensions */
+import { default as componentDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/datePickerInput/datePickerInput';
+/* eslint-enable import/no-named-default, import/extensions */
+
+function DatePickerInputDevSandbox() {
+    const {
+        description: componentDescription,
+        displayName: componentName,
+    } = componentDoc;
+
+    return (
+        <Main page={camelCase(componentName)}>
+            <Main.Content>
+                <MarkdownContainer>
+                    <Typography
+                        className="description"
+                        variant="body1"
+                    >
+                        {componentDescription}
+                    </Typography>
+
+                    <Heading
+                        anchorLink="disabled"
+                        variant="h2"
+                    >
+                        Disabled
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        <code>DatePickerInput</code>s can be disabled so that
+                        they are non-interactive.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputDisabled').default}
+                >
+                    <ExampleDatePickerInputDisabled />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="events"
+                        variant="h2"
+                    >
+                        Events
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can specify an array of Dates (Moment objects) that
+                        should be highlighted on the
+                        <code>DatePickerInput</code>&rsquo;s calendar control.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputEvents').default}
+                >
+                    <ExampleDatePickerInputEvents />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="exclude-dates"
+                        variant="h2"
+                    >
+                        Exclude Dates
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can specify an array of Dates (Moment objects) that
+                        should be excluded (unavailable for selection) on the
+                        <code>DatePickerInput</code>&rsquo;s calendar control.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputExcludeDates').default}
+                >
+                    <ExampleDatePickerInputExcludeDates />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="filter-dates"
+                        variant="h2"
+                    >
+                        Filter Dates
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can specify a predicate function to determine what
+                        dates should be available for selection.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputFilterDates').default}
+                >
+                    <ExampleDatePickerInputFilterDates />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="fluid"
+                        variant="h2"
+                    >
+                        Fluid
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        The <code>DatePickerInput</code> supports the
+                        <code>fluid</code> prop, like most input components.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputFluid').default}
+                >
+                    <ExampleDatePickerInputFluid />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="include-dates"
+                        variant="h2"
+                    >
+                        Include Dates
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can specify an array of Dates (Moment objects) that
+                        should are the <em>only</em> dates that are available
+                        for selection on the <code>DatePickerInput</code>&rsquo;s
+                        calendar control.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputIncludeDates').default}
+                >
+                    <ExampleDatePickerInputIncludeDates />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="label"
+                        variant="h2"
+                    >
+                        Label
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can add a label to the <code>DatePickerInput</code>.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputLabel').default}
+                >
+                    <ExampleDatePickerInputLabel />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="locale"
+                        variant="h2"
+                    >
+                        Locale
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can change the locale (e.g. <code>"en-US"</code> etc.)
+                        of the <code>DatePickerInput</code> for
+                        localization/internationalization purposes.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputLocale').default}
+                >
+                    <ExampleDatePickerInputLocale />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="max-date"
+                        variant="h2"
+                    >
+                        Max Date
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can specify a maximum selectable date for the
+                        <code>DatePickerInput</code>.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputMaxDate').default}
+                >
+                    <ExampleDatePickerInputMaxDate />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="min-date"
+                        variant="h2"
+                    >
+                        Min Date
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can specify a minimum selectable date for the
+                        <code>DatePickerInput</code>.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputMinDate').default}
+                >
+                    <ExampleDatePickerInputMinDate />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="on-change-event-handler"
+                        variant="h2"
+                    >
+                        <code style={{ color: '#1c2530' }}>onChange</code> Event Handler
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can use the <code>DatePickerInput</code> as a
+                        controlled component by using the <code>date</code> prop
+                        as the value and by handling the <code>onChange</code>
+                        event.<br />
+                        See also the <a href="#range">Range</a>&nbsp;section
+                        below for handling <code>onChange</code> when using
+                        <code>DatePickerInput</code>s to select a date range.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputOnChange').default}
+                >
+                    <ExampleDatePickerInputOnChange />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="on-month-change-event-handler"
+                        variant="h2"
+                    >
+                        <code style={{ color: '#1c2530' }}>onMonthChange</code> Event Handler
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        A consuming component can handle the
+                        <code>DatePickerInput</code>&rsquo;s
+                        <code>onMonthChange</code> event.  This is useful for
+                        scenarios such as needing to fetch new data for the
+                        newly selected month.<br />
+                        <br />
+                        <strong>IMPORTANT NOTE:</strong> Months are numbered 0
+                        through 11, (not 1 through 12), a Moment.Js convention,
+                        but clearly unusual in common usage.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputOnMonthChange').default}
+                >
+                    <ExampleDatePickerInputOnMonthChange />
+                </Example>
+
+                <MarkdownContainer>
+                    <Heading
+                        anchorLink="range"
+                        variant="h2"
+                    >
+                        Range
+                    </Heading>
+
+                    <Typography
+                        variant="body1"
+                    >
+                        You can use two <code>DatePickerInput</code>s to allow
+                        selection of a date range.
+                    </Typography>
+                </MarkdownContainer>
+
+                <Example
+                    rawCode={require('!!raw-loader!../examples/exampleDatePickerInputRange').default}
+                >
+                    <ExampleDatePickerInputRange />
+                </Example>
+            </Main.Content>
+        </Main>
+    );
+}
+
+export default DatePickerInputDevSandbox;

--- a/docs/src/inputs/datePickerInput/devSandbox/index.js
+++ b/docs/src/inputs/datePickerInput/devSandbox/index.js
@@ -1,0 +1,1 @@
+export { default } from './devSandbox';

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputBasic.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputBasic.jsx
@@ -1,0 +1,10 @@
+import { DatePickerInput } from 'react-cm-ui';
+import React from 'react';
+
+function ExampleDatePickerInputBasic() {
+    return (
+        <DatePickerInput />
+    );
+}
+
+export default ExampleDatePickerInputBasic;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputDisabled.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputDisabled.jsx
@@ -1,0 +1,26 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React, {
+    useCallback,
+    useState,
+} from 'react';
+
+function ExampleDatePickerInputDisabled() {
+    const [dateValue, setDateValue] = useState(moment());
+
+    const onDatePickerInputChange = useCallback(({ date }) => {
+        setDateValue(date);
+    }, [
+        setDateValue,
+    ]);
+
+    return (
+        <DatePickerInput
+            date={dateValue}
+            disable
+            onChange={onDatePickerInputChange}
+        />
+    );
+}
+
+export default ExampleDatePickerInputDisabled;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputEvents.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputEvents.jsx
@@ -1,0 +1,18 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function ExampleDatePickerInputEvents() {
+    return (
+        <DatePickerInput
+            events={[
+                moment().subtract(1, 'days'),
+                moment().subtract(2, 'days'),
+                moment().subtract(3, 'days'),
+                moment().subtract(4, 'days'),
+            ]}
+        />
+    );
+}
+
+export default ExampleDatePickerInputEvents;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputExcludeDates.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputExcludeDates.jsx
@@ -1,0 +1,18 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function ExampleDatePickerInputExcludeDates() {
+    return (
+        <DatePickerInput
+            excludeDates={[
+                moment().subtract(1, 'days'),
+                moment().subtract(2, 'days'),
+                moment().subtract(3, 'days'),
+                moment().subtract(4, 'days'),
+            ]}
+        />
+    );
+}
+
+export default ExampleDatePickerInputExcludeDates;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputFilterDates.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputFilterDates.jsx
@@ -1,0 +1,18 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function isWeekend(date) {
+    const day = date.day();
+    return day === 0 || day === 6;
+}
+
+function ExampleDatePickerInputFilterDates() {
+    return (
+        <DatePickerInput
+            filterDates={isWeekend}
+        />
+    );
+}
+
+export default ExampleDatePickerInputFilterDates;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputFluid.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputFluid.jsx
@@ -1,0 +1,36 @@
+import { DatePickerInput } from 'react-cm-ui';
+import React from 'react';
+
+function ExampleDatePickerInputFluid() {
+    return (
+        <div
+            style={{
+                backgroundColor: '#f6f7f8',
+                border: 'solid 1px #dbe0e3',
+                padding: '11px 22px 22px',
+                width: '33.33%',
+            }}
+        >
+            <p
+                style={{
+                    color: '#97a4ab',
+                    marginTop: 0,
+                }}
+            >
+                Some Container
+            </p>
+
+            <DatePickerInput
+                label="Regular"
+            />
+
+            <DatePickerInput
+                fluid
+                label="Fluid"
+                style={{ marginTop: 22 }}
+            />
+        </div>
+    );
+}
+
+export default ExampleDatePickerInputFluid;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputIncludeDates.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputIncludeDates.jsx
@@ -1,0 +1,18 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function ExampleDatePickerInputIncludeDates() {
+    return (
+        <DatePickerInput
+            includeDates={[
+                moment().subtract(1, 'days'),
+                moment().subtract(2, 'days'),
+                moment().subtract(3, 'days'),
+                moment().subtract(4, 'days'),
+            ]}
+        />
+    );
+}
+
+export default ExampleDatePickerInputIncludeDates;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputLabel.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputLabel.jsx
@@ -1,0 +1,12 @@
+import { DatePickerInput } from 'react-cm-ui';
+import React from 'react';
+
+function ExampleDatePickerInputLabel() {
+    return (
+        <DatePickerInput
+            label="The Coolest Label Ever"
+        />
+    );
+}
+
+export default ExampleDatePickerInputLabel;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputMaxDate.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputMaxDate.jsx
@@ -1,0 +1,13 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function ExampleDatePickerInputMaxDate() {
+    return (
+        <DatePickerInput
+            maxDate={moment()}
+        />
+    );
+}
+
+export default ExampleDatePickerInputMaxDate;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputMinDate.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputMinDate.jsx
@@ -1,0 +1,13 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function ExampleDatePickerInputMinDate() {
+    return (
+        <DatePickerInput
+            minDate={moment().subtract(7, 'days')}
+        />
+    );
+}
+
+export default ExampleDatePickerInputMinDate;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputOnChange.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputOnChange.jsx
@@ -1,0 +1,25 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React, {
+    useCallback,
+    useState,
+} from 'react';
+
+function ExampleDatePickerInputOnChange() {
+    const [dateValue, setDateValue] = useState(moment());
+
+    const onDatePickerInputChange = useCallback(({ date }) => {
+        setDateValue(date);
+    }, [
+        setDateValue,
+    ]);
+
+    return (
+        <DatePickerInput
+            date={dateValue}
+            onChange={onDatePickerInputChange}
+        />
+    );
+}
+
+export default ExampleDatePickerInputOnChange;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputOnMonthChange.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputOnMonthChange.jsx
@@ -1,0 +1,22 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function onMonthChanged(month, year) {
+    const newMonth = moment()
+        .month(month)
+        .year(year)
+        .format('MMMM YYYY');
+
+    window.alert(`The month was changed!  Now it is ${newMonth}.`);
+}
+
+function ExampleDatePickerInputOnMonthChange() {
+    return (
+        <DatePickerInput
+            onMonthChange={onMonthChanged}
+        />
+    );
+}
+
+export default ExampleDatePickerInputOnMonthChange;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputRange.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerInputRange.jsx
@@ -1,0 +1,42 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React, {
+    useCallback,
+    useState,
+} from 'react';
+
+function ExampleDatePickerInputRange() {
+    const [dateRangeFrom, setDateRangeFrom] = useState(moment());
+    const [dateRangeTo, setDateRangeTo] = useState(moment());
+
+    const onDatePickerInputChange = useCallback(({ dateFrom, dateTo }) => {
+        setDateRangeFrom(dateFrom);
+        setDateRangeTo(dateTo);
+    }, [
+        setDateRangeFrom,
+        setDateRangeTo,
+    ]);
+
+    return (
+        <React.Fragment>
+            <DatePickerInput
+                dateFrom={dateRangeFrom}
+                dateTo={dateRangeTo}
+                label="From"
+                onChange={onDatePickerInputChange}
+                rangeFrom
+            />
+
+            <DatePickerInput
+                dateFrom={dateRangeFrom}
+                dateTo={dateRangeTo}
+                label="To"
+                onChange={onDatePickerInputChange}
+                rangeTo
+                style={{ marginLeft: 22 }}
+            />
+        </React.Fragment>
+    );
+}
+
+export default ExampleDatePickerInputRange;

--- a/docs/src/inputs/datePickerInput/examples/exampleDatePickerinputLocale.jsx
+++ b/docs/src/inputs/datePickerInput/examples/exampleDatePickerinputLocale.jsx
@@ -1,0 +1,13 @@
+import { DatePickerInput } from 'react-cm-ui';
+import moment from 'moment-timezone';
+import React from 'react';
+
+function ExampleDatePickerInputLocale() {
+    return (
+        <DatePickerInput
+            locale={moment().locale()}
+        />
+    );
+}
+
+export default ExampleDatePickerInputLocale;

--- a/docs/src/inputs/timePicker/devSandbox/devSandbox.jsx
+++ b/docs/src/inputs/timePicker/devSandbox/devSandbox.jsx
@@ -16,7 +16,7 @@ import Heading from '../../../global/heading';
 import Main from '../../../global/main';
 import MarkdownContainer from '../../../global/markdownContainer';
 /* eslint-disable import/no-named-default, import/extensions */
-import { default as rootDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/select/select';
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!react-cm-ui/inputs/timePicker/timePicker';
 /* eslint-enable import/no-named-default, import/extensions */
 
 function TimePickerDevSandbox() {

--- a/src/inputs/datePickerInput/__test__/datePickerInput.test.js
+++ b/src/inputs/datePickerInput/__test__/datePickerInput.test.js
@@ -1,0 +1,147 @@
+/**
+ * To run this test:
+ * npx jest ./src/inputs/datePickerInput/__test__/datePickerInput.test.js
+ */
+import moment from 'moment-timezone';
+import React from 'react';
+import {
+    fireEvent,
+    render,
+    screen,
+} from '../../../testUtils';
+import DatePickerInput from '../datePickerInput.jsx';
+
+describe('<DatePickerInput />', () => {
+    describe('render()', () => {
+        it('OK (all default props)', () => {
+            const props = {
+                dataTestId: `foo_block--bar_date_picker_input`,
+            }
+
+            render(
+                <DatePickerInput {...props} />,
+            );
+
+            expect(screen.queryByTestId(props.dataTestId)).toBeInTheDocument();
+        });
+
+        it('OK (has a date value)', () => {
+            const props = {
+                dataTestId: `foo_block--bar_date_picker_input`,
+                date: moment.utc('2022-01-10T00:00:00'),
+            }
+
+            render(
+                <DatePickerInput {...props} />,
+            );
+
+            expect(screen.queryByTestId(props.dataTestId)).toBeInTheDocument();
+            expect(screen.queryByDisplayValue(props.date.format('MM/DD/YYYY'))).toBeInTheDocument();
+        });
+    });
+
+    describe('Change event', () => {
+        it('Works (single date value)', () => {
+            const props = {
+                dataTestId: `foo_block--bar_date_picker_input`,
+                date: null,
+                onChange: jest.fn(),
+            }
+
+            const { getByTestId } = render(
+                <DatePickerInput {...props} />,
+            );
+
+            const datePickerInput = getByTestId(props.dataTestId);
+            const newDateValue = '01/10/2022'; // MM/DD/YYYY
+
+            fireEvent.change(
+                datePickerInput,
+                {
+                    target: {
+                        value: newDateValue,
+                    },
+                },
+            );
+
+            expect(screen.queryByDisplayValue(newDateValue)).toBeInTheDocument();
+
+            expect(props.onChange).toHaveBeenCalledTimes(1);
+            const onChangeArgObj = props.onChange.mock.calls[0][0];
+            const onChangeSingleDateArg = onChangeArgObj.date;
+            expect(moment.isMoment(onChangeSingleDateArg)).toBe(true);
+            expect(onChangeSingleDateArg.format('MM/DD/YYYY')).toEqual(newDateValue);
+        });
+
+        it('Works (date range - from)', () => {
+            const props = {
+                dataTestId: `foo_block--bar_date_picker_input`,
+                onChange: jest.fn(),
+                rangeFrom: true,
+            }
+
+            const { getByTestId } = render(
+                <DatePickerInput {...props} />,
+            );
+
+            const datePickerInput = getByTestId(props.dataTestId);
+            const newDateValue = '01/01/2022'; // MM/DD/YYYY
+
+            fireEvent.change(
+                datePickerInput,
+                {
+                    target: {
+                        value: newDateValue,
+                    },
+                },
+            );
+
+            expect(screen.queryByDisplayValue(newDateValue)).toBeInTheDocument();
+
+            expect(props.onChange).toHaveBeenCalledTimes(1);
+            const onChangeArgObj = props.onChange.mock.calls[0][0];
+            const onChangeDateFromArg = onChangeArgObj.dateFrom;
+            expect(moment.isMoment(onChangeDateFromArg)).toBe(true);
+            expect(onChangeDateFromArg.format('MM/DD/YYYY')).toEqual(newDateValue);
+        });
+
+        it('Works (date range - to)', () => {
+            const props = {
+                dataTestId: `foo_block--bar_date_picker_input`,
+                onChange: jest.fn(),
+                dateFrom: moment.utc('2022-01-01T00:00:00'),
+                rangeTo: true,
+            }
+
+            const { getByTestId } = render(
+                <DatePickerInput {...props} />,
+            );
+
+            const datePickerInput = getByTestId(props.dataTestId);
+            const newDateValue = '01/10/2022'; // MM/DD/YYYY
+
+            fireEvent.change(
+                datePickerInput,
+                {
+                    target: {
+                        value: newDateValue,
+                    },
+                },
+            );
+
+            expect(screen.queryByDisplayValue(newDateValue)).toBeInTheDocument();
+
+            expect(props.onChange).toHaveBeenCalledTimes(1);
+
+            const onChangeArgObj = props.onChange.mock.calls[0][0];
+
+            const onChangeDateFromArg = onChangeArgObj.dateFrom;
+            expect(moment.isMoment(onChangeDateFromArg)).toBe(true);
+            expect(onChangeDateFromArg.isSame(props.dateFrom)).toBe(true);
+
+            const onChangeDateToArg = onChangeArgObj.dateTo;
+            expect(moment.isMoment(onChangeDateToArg)).toBe(true);
+            expect(onChangeDateToArg.format('MM/DD/YYYY')).toEqual(newDateValue);
+        });
+    });
+});

--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -7,10 +7,14 @@ import {
 } from 'lodash';
 import ClassNames from 'classnames';
 import moment from 'moment-timezone';
+import MomentPropTypes from 'react-moment-proptypes';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TetherComponent from 'react-tether';
+import {
+    UI_CLASS_NAME,
+} from '../../global/constants';
 import DatePickerUtils from '../../utils/datePickerUtils';
 import DateUtils from '../../utils/dateUtils';
 import Icon from '../../dataDisplay/icon';
@@ -23,47 +27,153 @@ const propTypes = {
      * Override or extend the styles applied to DatePickerInput.
      */
     classes: PropTypes.shape({
+        isFluid: PropTypes.string,
         root: PropTypes.string,
     }),
+
+    /**
+    * Assign additional class names to DatePickerInput.
+    */
     className: PropTypes.string,
-    date: PropTypes.shape({}),
+
+    /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
+
+    /**
+     * Single date value.  Moment object.
+     */
+    date: MomentPropTypes.momentObj,
+
+    /**
+     * 'From' ('Start') Date for a Date Range.  Moment object.
+     */
     dateFrom: PropTypes.shape({}),
+
+    /**
+     * 'To' ('End') Date for a Date Range.  Moment object.
+     */
     dateTo: PropTypes.shape({}),
+
     /**
      * A DatePickerInput can be disabled.
      */
     disable: PropTypes.bool,
+
     /**
      * Deprecated prop. Please use `disable` instead.
      */
     disabled: PropTypes.bool,
+
+    /**
+     * String specifying the way the date value will be formatted.
+     */
     displayFormat: PropTypes.string,
+
+    /**
+     * Indicate that there is a validation error for this DatePickerInput control.
+     */
     errorMessage: PropTypes.string,
-    events: PropTypes.arrayOf(PropTypes.shape({})),
-    excludeDates: PropTypes.arrayOf(PropTypes.shape({})),
+
+    /**
+     * Indicates dates that should be highlighted on the DatePickerInput's calendar control.  Array of Moment objects.
+     */
+    events: PropTypes.arrayOf(MomentPropTypes.momentObj),
+
+    /**
+     * Specifies a range of dates that are not selectable.  Array of Moment objects.
+     */
+    excludeDates: PropTypes.arrayOf(MomentPropTypes.momentObj),
+
+    /**
+     * Function that is used to filter out dates that are to not be selectable.
+     */
     filterDates: PropTypes.func,
+
+    /**
+     * The DatePickerInput will be resized to its parent container's width.
+     */
+    fluid: PropTypes.bool,
+
+    /**
+     * Specify an element ID this DatePickerInput control.
+     */
     id: PropTypes.oneOfType([
         PropTypes.number,
         PropTypes.string,
     ]),
-    includeDates: PropTypes.arrayOf(PropTypes.shape({})),
+
+    /**
+     * Specifies a range of dates that are selectable.  Array of Moment objects.
+     */
+    includeDates: PropTypes.arrayOf(MomentPropTypes.momentObj),
+
+    /**
+     * Specifies a label for the DatePickerInput control.
+     */
     label: PropTypes.string,
+
+    /**
+     * Specifies which locale will be used when formatting date values.
+     */
     locale: PropTypes.string,
-    maxDate: PropTypes.shape({}),
-    minDate: PropTypes.shape({}),
+
+    /**
+     * Specifies maximum selectable date.  Moment object.
+     */
+    maxDate: MomentPropTypes.momentObj,
+
+    /**
+     * Specifies minimum selectable date.   Moment object.
+     */
+    minDate: MomentPropTypes.momentObj,
+
+    /**
+     * DatePickerInput can handle an onBlur event from parent.
+     */
     onBlur: PropTypes.func,
+
+    /**
+     * Event handler for consumer to control state outside of the DatePickerInput.
+     */
     onChange: PropTypes.func,
+
+    /**
+     * Event handler called when the month in the DatePickerInput's calendar control changes.
+     */
     onMonthChange: PropTypes.func,
+
+    /**
+     * If true, specifies that the DatePickerInput represents the 'From' (or 'Start') date of a date range.
+     */
     rangeFrom: PropTypes.bool,
+
+    /**
+     * If true, specifies that the DatePickerInput represents the 'To' (or 'End') date of a date range.
+     */
     rangeTo: PropTypes.bool,
+
+    /**
+     * Indicates whether the DatePickerInput control represents a required field.
+     */
     required: PropTypes.bool,
+
+    /**
+     * Supply any inline styles to the DatePickerInput's container. Mainly used for padding and margins.
+     */
     style: PropTypes.shape({}),
+
+    /**
+     * Allows the DatePickerInput to be focused via the Tab key.
+     */
     tabIndex: PropTypes.number,
 };
 
 const defaultProps = {
     classes: null,
     className: null,
+    dataTestId: undefined,
     date: null,
     dateFrom: null,
     dateTo: null,
@@ -74,6 +184,7 @@ const defaultProps = {
     events: null,
     excludeDates: null,
     filterDates: null,
+    fluid: false,
     id: null,
     includeDates: null,
     label: null,
@@ -93,7 +204,11 @@ const defaultProps = {
 const styles = (theme) => ({
     root: {
         display: 'inline-block',
+        '&$isFluid': {
+            width: '100%',
+        },
     },
+    isFluid: {},
     '@global': {
         '.date-picker-tether-element': {
             zIndex: theme.zIndex.datePickerInputCalendar,
@@ -356,12 +471,14 @@ class DatePickerInput extends React.PureComponent {
             classes,
             className,
             errorMessage,
+            dataTestId,
             disable,
             disabled,
             displayFormat,
             events,
             excludeDates,
             filterDates,
+            fluid,
             id,
             includeDates,
             label,
@@ -387,6 +504,9 @@ class DatePickerInput extends React.PureComponent {
             'date-picker-input',
             classes.root,
             className,
+            {
+                [classes.isFluid]: fluid,
+            },
         );
 
         let iconColor;
@@ -450,7 +570,9 @@ class DatePickerInput extends React.PureComponent {
                             <Input
                                 autoComplete="off"
                                 data-parsley-error-message={errorMessage}
+                                dataTestId={dataTestId}
                                 disable={isDisabled}
+                                fluid={fluid}
                                 guide
                                 icon={(
                                     <Icon

--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -49,12 +49,12 @@ const propTypes = {
     /**
      * 'From' ('Start') Date for a Date Range.  Moment object.
      */
-    dateFrom: PropTypes.shape({}),
+    dateFrom: MomentPropTypes.momentObj,
 
     /**
      * 'To' ('End') Date for a Date Range.  Moment object.
      */
-    dateTo: PropTypes.shape({}),
+    dateTo: MomentPropTypes.momentObj,
 
     /**
      * A DatePickerInput can be disabled.
@@ -216,6 +216,14 @@ const styles = (theme) => ({
     },
 });
 
+/**
+ * The DatePickerInput represents an input for storing a date value.
+ *
+ * When clicked, it can display an interactive calendar control for selecting
+ * the date.
+ *
+ * A date value can also be typed into the input manually.
+ */
 class DatePickerInput extends React.PureComponent {
     constructor(props) {
         super(props);

--- a/src/inputs/input/input.jsx
+++ b/src/inputs/input/input.jsx
@@ -18,6 +18,10 @@ const propTypes = {
     autoFocus: PropTypes.bool,
     className: PropTypes.string,
     /**
+     * Used for DOM testing. https://testing-library.com/docs/queries/bytestid/
+     */
+    dataTestId: PropTypes.string,
+    /**
      * An Input can be disabled.
      */
     disable: PropTypes.bool,
@@ -75,6 +79,7 @@ const defaultProps = {
     autoComplete: null,
     autoFocus: null,
     className: null,
+    dataTestId: undefined,
     disable: false,
     disabled: false,
     error: null,
@@ -378,6 +383,7 @@ class Input extends React.PureComponent {
         const {
             autoComplete,
             className,
+            dataTestId,
             disable,
             disabled,
             error,
@@ -404,14 +410,17 @@ class Input extends React.PureComponent {
             showSpinners,
             value,
         } = this.props;
+
         const {
             isFocused,
             inputActionsTopPosition,
             showRequiredIndicator,
         } = this.state;
+
         const type = this.getType();
         const newLabelPosition = labelPosition || 'top';
         const isDisabled = disable || disabled;
+
         const containerClasses = ClassNames('ui', 'input', className, {
             'input-disabled': isDisabled,
             'input-error': error,
@@ -427,10 +436,12 @@ class Input extends React.PureComponent {
             'input-type-tel': type === 'tel',
             'input-type-text': type === 'text',
         });
+
         const labelContainerClassNames = ClassNames('label', {
             'label-bottom': newLabelPosition === 'bottom',
             'label-top': newLabelPosition === 'top',
         });
+
         const renderLabel = () => {
             if (!label) {
                 return null;
@@ -454,6 +465,7 @@ class Input extends React.PureComponent {
                 {mask ? (
                     <InputMasked
                         autoComplete={autoComplete}
+                        data-testid={dataTestId}
                         disabled={isDisabled}
                         guide={guide}
                         id={id}
@@ -478,6 +490,7 @@ class Input extends React.PureComponent {
                 ) : (
                     <input
                         autoComplete={autoComplete}
+                        data-testid={dataTestId}
                         disabled={isDisabled}
                         id={id}
                         name={name}

--- a/src/versions.js
+++ b/src/versions.js
@@ -53,6 +53,11 @@ const versions = {
                 },
             },
             inputs: {
+                datePickerInput: {
+                    devLibraryVersion: '2.0.0', // Is this correct?
+                    designLibraryVersion: 'N/A', // Does anything go here?
+                    designLibraryDoc: 'N/A', // Does anything go here?
+                },
                 dropdownButton: {
                     devLibraryVersion: '2.0.0',
                     designLibraryVersion: '2.0.0',

--- a/src/versions.js
+++ b/src/versions.js
@@ -54,9 +54,9 @@ const versions = {
             },
             inputs: {
                 datePickerInput: {
-                    devLibraryVersion: '2.0.0', // Is this correct?
-                    designLibraryVersion: 'N/A', // Does anything go here?
-                    designLibraryDoc: 'N/A', // Does anything go here?
+                    devLibraryVersion: '1.0.0',
+                    designLibraryVersion: 'N/A',
+                    designLibraryDoc: 'N/A',
                 },
                 dropdownButton: {
                     devLibraryVersion: '2.0.0',


### PR DESCRIPTION
**[Product Backlog Item AB#58900](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/58900) | [AI.2.1] - Ability to export a list of entries (Export for Connection Forms 2.0)**

See:
https://github.com/saddlebackdev/church-management/pull/5767 (esp. https://github.com/saddlebackdev/church-management/pull/5767#discussion_r777645030)
https://github.com/saddlebackdev/church-management/pull/5794

**Scope of Work:**
* Add `fluid` prop to `<DatePickerInput>`
* Add `dataTestId` support for `<DatePickerInput>` and add a unit test fixture for it, testing basic render and `onChange` event handling.
  * Also had to add `dataTestId` support for `<Input>`.
  * When you specify a `dataTestId` for `<DatePickerInput>` it actually is passed into the `<Input>` and ends up as a `data-testid` attribute on the underling HTML `<input>` element.
  * The rationale here is that the likeliest unit testing scenario (for higher level molecules and organisms using `<DatePickerInput>`) is needing to be able to trigger a change event and specify a value to the `<DatePickerInput>` directly (i.e. not attempting to interact with the calendar control).
* Refactor/modernize the documentation for `<DatePickerInput>`
  * Divide into main page, Dev Sandbox section, and API section
  * Move all examples into separate component files and refactor them to use functional style.