### PR TITLE
[dev] [No Bug/PBI] Fix `data-testid` issue for `<DataGroups>`

### DIFF
--- a/docs/src/layout/page/demo/demo.jsx
+++ b/docs/src/layout/page/demo/demo.jsx
@@ -545,7 +545,7 @@ class PageDemo extends React.PureComponent {
             maritalStatus: maritalStatus || '',
         };
 
-        const mainCoulumn = [];
+        const mainColumns = [];
 
         const personalColumnInfo = {
             isExpandable: true,
@@ -630,7 +630,7 @@ class PageDemo extends React.PureComponent {
             ],
         };
 
-        mainCoulumn.push(personalColumnInfo);
+        mainColumns.push(personalColumnInfo);
 
         let personPhonesExpandableRows;
         if (!_.isEmpty(phones)) {
@@ -759,7 +759,7 @@ class PageDemo extends React.PureComponent {
                 },
             ],
         };
-        mainCoulumn.push(contactColumnInfo);
+        mainColumns.push(contactColumnInfo);
 
         if (!_.isEmpty(personOccupationInfo)) {
             let occupationsExpandableSection;
@@ -838,7 +838,7 @@ class PageDemo extends React.PureComponent {
                 expandableSections: occupationsExpandableSection,
             };
 
-            mainCoulumn.push(occupationColumnInfo);
+            mainColumns.push(occupationColumnInfo);
 
             const fooColumnInfo = {
                 header: '4 Column',
@@ -850,7 +850,7 @@ class PageDemo extends React.PureComponent {
                 ],
             };
 
-            mainCoulumn.push(fooColumnInfo);
+            mainColumns.push(fooColumnInfo);
 
             const barColumnInfo = {
                 header: '5 Column',
@@ -862,7 +862,7 @@ class PageDemo extends React.PureComponent {
                 ],
             };
 
-            mainCoulumn.push(barColumnInfo);
+            mainColumns.push(barColumnInfo);
         }
 
         return (
@@ -1137,7 +1137,7 @@ class PageDemo extends React.PureComponent {
                                 className={classes.dataGroupsContainer}
                             >
                                 <Page.DataGroups
-                                    columns={mainCoulumn}
+                                    columns={mainColumns}
                                     data={mainData}
                                 />
                             </div> */}

--- a/src/dataDisplay/dataGroups/__test__/dataGroups.test.js
+++ b/src/dataDisplay/dataGroups/__test__/dataGroups.test.js
@@ -67,7 +67,6 @@ describe('<DataGroups />', () => {
         expect(rootDataGroupsContainer).toHaveClass(className);
         expect(screen.queryByText('Column 1')).toBeInTheDocument();
         expect(screen.queryByText('Column 2')).toBeInTheDocument();
-        expect(screen.queryByText('Column 1')).toBeInTheDocument();
         expect(screen.queryByText('Foo Property Title')).toBeInTheDocument();
         expect(screen.queryByText('Foo Property Value')).toBeInTheDocument();
         expect(screen.queryByText('Bar Property Title')).toBeInTheDocument();

--- a/src/dataDisplay/dataGroups/__test__/dataGroups.test.js
+++ b/src/dataDisplay/dataGroups/__test__/dataGroups.test.js
@@ -1,0 +1,80 @@
+/**
+ * To run this test:
+ * npx jest ./src/dataDisplay/dataGroups/__test__/dataGroups.test.js
+ */
+import React from 'react';
+import {
+ render,
+ screen,
+} from '../../../testUtils';
+import DataGroups from '../dataGroups.jsx';
+
+const someDataObject = {
+    foo: 'Foo Property Value',
+    bar: 'Bar Property Value',
+    baz: 'Baz Property Value',
+    qux: 'Qux Property Value',
+};
+
+const columns = [
+    {
+        header: 'Column 1',
+        rows: [
+            {
+                accessor: 'foo',
+                fieldName: 'Foo Property Title',
+            },
+            {
+                accessor: 'bar',
+                fieldName: 'Bar Property Title',
+            },
+        ],
+    },
+    {
+        header: 'Column 2',
+        rows: [
+            {
+                accessor: 'baz',
+                fieldName: 'Baz Property Title',
+            },
+            {
+                accessor: 'qux',
+                fieldName: 'Qux Property Title',
+            },
+        ]
+    },
+];
+
+const className = 'some_block--data_groups';
+const dataTestId = 'unit_test_data_groups_test_id';
+
+const props = {
+    className,
+    columns,
+    data: someDataObject,
+    dataTestId,
+    moduleType: 'page',
+};
+
+describe('<DataGroups />', () => {
+    it('Renders correctly', () => {
+        render(
+            <DataGroups {...props} />,
+        );
+
+        const rootDataGroupsContainer = screen.queryByTestId(props.dataTestId);
+        expect(rootDataGroupsContainer).toBeInTheDocument();
+        expect(rootDataGroupsContainer).toHaveClass(className);
+        expect(screen.queryByText('Column 1')).toBeInTheDocument();
+        expect(screen.queryByText('Column 2')).toBeInTheDocument();
+        expect(screen.queryByText('Column 1')).toBeInTheDocument();
+        expect(screen.queryByText('Foo Property Title')).toBeInTheDocument();
+        expect(screen.queryByText('Foo Property Value')).toBeInTheDocument();
+        expect(screen.queryByText('Bar Property Title')).toBeInTheDocument();
+        expect(screen.queryByText('Bar Property Value')).toBeInTheDocument();
+        expect(screen.queryByText('Baz Property Title')).toBeInTheDocument();
+        expect(screen.queryByText('Baz Property Value')).toBeInTheDocument();
+        expect(screen.queryByText('Qux Property Title')).toBeInTheDocument();
+        expect(screen.queryByText('Qux Property Value')).toBeInTheDocument();
+    });
+});

--- a/src/dataDisplay/dataGroups/dataGroups.jsx
+++ b/src/dataDisplay/dataGroups/dataGroups.jsx
@@ -123,7 +123,7 @@ class DataGroups extends React.PureComponent {
         return (
             <div
                 className={rootClasses}
-                dataTestId={dataTestId}
+                data-testid={dataTestId}
                 ref={(ref) => { this.dataGroups = ref; }}
                 style={style}
             >

--- a/src/surfaces/actionBar/actionBar.jsx
+++ b/src/surfaces/actionBar/actionBar.jsx
@@ -308,7 +308,7 @@ class ActionBar extends React.PureComponent {
                                                 <Button
                                                     color={button.color}
                                                     designVersion={1}
-                                                    disabled={!!button.disabled}
+                                                    disable={!!button.disable || !!button.disabled}
                                                     icon={button.iconType && !button.label}
                                                     id={button.id}
                                                     onClick={button.onClick}
@@ -340,7 +340,7 @@ class ActionBar extends React.PureComponent {
                                                         return (
                                                             <DropdownButton.Option
                                                                 className={option.className}
-                                                                disabled={!!option.disabled}
+                                                                disable={!!option.disable || !!option.disabled}
                                                                 id={option.id}
                                                                 key={`action_bar_dropdown_button_option-${dropdownButtonOptionKeyNum}`}
                                                                 label={option.label}


### PR DESCRIPTION
This fixes the following warning (and makes the `data-testid` actually useful!)
```
react_devtools_backend.js:4061 Warning: React does not recognize the `dataTestId` prop on a DOM element.
If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `datatestid` instead.
If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by DataGroups)
    in DataGroups (created by PageDataGroups)
    in PageDataGroups (created by [Some Component Using Page Data Groups])
    ...
```
Also adds a unit test fixture for `<DataGroups>` and fixes a typo I noticed in `<DemoPage>` in the docs.