### PR TITLE
[dev] Bug AB#59185 [Mobile][My Ministries > Serving Opps] After adding a new Opportunity in My Ministry, the "Actions" pop out drawer does not close automatically | Extend Mobile Action Bar Actions Button and Actions Drawer to provide the option of toggling the Actions Drawer closed when an option is clicked

### DIFF
--- a/src/surfaces/actionBar/actionBarActionsButton.jsx
+++ b/src/surfaces/actionBar/actionBarActionsButton.jsx
@@ -208,6 +208,7 @@ class ActionBarActionsButton extends React.PureComponent {
                                         key={`actions_button_drawer--option-${optionKeyNum}`}
                                         onClick={this.onOptionClick}
                                         onRequestPrompt={this.onPromptRequested}
+                                        onDrawerToggle={this.onDrawerToggle}
                                         option={option}
                                     />
                                 );

--- a/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
+++ b/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
@@ -19,6 +19,7 @@ const propTypes = {
     isSelected: PropTypes.bool,
     onClick: PropTypes.func.isRequired,
     onRequestPrompt: PropTypes.func,
+    onDrawerToggle: PropTypes.func,
     option: PropTypes.shape(rootOptionPropTypeShape).isRequired,
 };
 
@@ -27,6 +28,7 @@ const defaultProps = {
     idNumber: false,
     isSelected: false,
     onRequestPrompt: undefined,
+    onDrawerToggle: undefined,
 };
 
 class ActionBarActionsButtonDrawerOption extends React.PureComponent {
@@ -41,6 +43,7 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
             isSelected,
             onClick,
             onRequestPrompt,
+            onDrawerToggle,
             option,
         } = this.props;
 
@@ -56,7 +59,7 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
                 }
             }
 
-            option.onClick();
+            option.onClick(onDrawerToggle);
             return false;
         }
 

--- a/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
+++ b/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
@@ -73,6 +73,7 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
             idNumber,
             isSelected,
             onRequestPrompt,
+            onDrawerToggle,
             option,
         } = this.props;
 
@@ -148,6 +149,7 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
                                     isSelected={isSelected}
                                     key={`actions_button_drawer_sub_option-${subOptionKeyNum++/* eslint-disable-line no-plusplus */}`}
                                     onRequestPrompt={onRequestPrompt}
+                                    onDrawerToggle={onDrawerToggle}
                                     subOption={subOption}
                                     subOptionClassNameNum={classNameNumber}
                                 />

--- a/src/surfaces/actionBar/actionBarActionsButtonDrawerSubOption.jsx
+++ b/src/surfaces/actionBar/actionBarActionsButtonDrawerSubOption.jsx
@@ -26,12 +26,14 @@ export const singleOptionPropTypeShape = {
 const propTypes = {
     isSelected: PropTypes.bool.isRequired,
     onRequestPrompt: PropTypes.func,
+    onDrawerToggle: ropTypes.func,
     subOption: PropTypes.shape(singleOptionPropTypeShape).isRequired,
     subOptionClassNameNum: PropTypes.number.isRequired,
 };
 
 const defaultProps = {
     onRequestPrompt: undefined,
+    onDrawerToggle: undefined,
 };
 
 class ActionBarActionsButtonDrawerSubOption extends React.PureComponent {
@@ -62,6 +64,7 @@ class ActionBarActionsButtonDrawerSubOption extends React.PureComponent {
     onClick() {
         const {
             onRequestPrompt,
+            onDrawerToggle,
             subOption,
         } = this.props;
         const {
@@ -85,6 +88,7 @@ class ActionBarActionsButtonDrawerSubOption extends React.PureComponent {
         }
 
         if (isFunction(subOptionOnClick)) {
+            onDrawerToggle();
             subOptionOnClick();
         }
 


### PR DESCRIPTION
See: https://github.com/saddlebackdev/church-management/pull/5874#discussion_r797350027
This is the React CM UI change required for "Solution 2".