### PR TITLE
[dev] Bug AB#59185 [Mobile][My Ministries > Serving Opps] After adding a new Opportunity in My Ministry, the "Actions" pop out drawer does not close automatically | Extend Mobile Action Bar Actions Button and Actions Drawer to provide the option of toggling the Actions Drawer closed when an option is clicked

### DIFF
--- a/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
+++ b/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
@@ -59,7 +59,8 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
                 }
             }
 
-            option.onClick(onDrawerToggle);
+            onDrawerToggle();
+            option.onClick();
             return false;
         }
 

--- a/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
+++ b/src/surfaces/actionBar/actionBarActionsButtonDrawerOption.jsx
@@ -49,23 +49,22 @@ class ActionBarActionsButtonDrawerOption extends React.PureComponent {
 
         if (_.isFunction(option.onClick)) {
             if (option.disabled) {
-                return false;
+                return;
             }
 
             if (option.requiresPrompt) {
                 if (_.isFunction(onRequestPrompt)) {
                     onRequestPrompt(option);
-                    return false;
+                    return;
                 }
             }
 
             onDrawerToggle();
             option.onClick();
-            return false;
+            return;
         }
 
         onClick(isSelected ? {} : option);
-        return true;
     }
 
     render() {


### PR DESCRIPTION
Execute onDrawerToggle instead of passing to parent component