### PR TITLE
[hotfix/10.3.9-hotfix] Bug AB#66203 [My Ministries > Serving Opps] - User cannot click on the checkbox to edit the venue Capacity, when creating a new SO

### DIFF
--- a/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
@@ -3,9 +3,9 @@
  * npx jest ./src/dataDisplay/personPanel/__test__/personPanelDetails.test.js
  */
 import React from 'react';
-import mountWithTheme from '../../../testUtils/enzymeHelpers';
-import PersonPanelDetails from '../personPanelDetails';
-import { ENTER_KEY_CODE } from '../../../global/constants';
+import mountWithTheme from '../../../testUtils/enzymeHelpers.jsx';
+import PersonPanelDetails from '../personPanelDetails.jsx';
+import KeyCode from '../../../global/keyCode.js';
 
 describe('<PersonPanelDetails />', () => {
     const helloWorld = 'hello world';
@@ -240,7 +240,7 @@ describe('<PersonPanelDetails />', () => {
         const selectButton = wrapper.find('.block_name--select').first();
 
         selectButton.simulate('click');
-        selectButton.props().onKeyDown({ keyCode: ENTER_KEY_CODE });
+        selectButton.props().onKeyDown({ keyCode: KeyCode.Enter });
 
         expect(selectButton).toBeDefined();
         expect(props.selectButtonProps.onClick).toHaveBeenCalledTimes(1);
@@ -249,13 +249,12 @@ describe('<PersonPanelDetails />', () => {
         const viewRecordButton = wrapper.find('.block_name--view_record').first();
 
         viewRecordButton.simulate('click');
-        viewRecordButton.props().onKeyDown({ keyCode: ENTER_KEY_CODE });
+        viewRecordButton.props().onKeyDown({ keyCode: KeyCode.Enter });
 
         expect(viewRecordButton).toBeDefined();
         expect(props.viewRecordButtonProps.onClick).toHaveBeenCalledTimes(1);
         expect(props.viewRecordButtonProps.onKeyDown).toHaveBeenCalledTimes(1);
     });
-
 
     it('Should disable select record button and apply a custom label using \'selectButtonProps\'', () => {
         const testCaseProps = {

--- a/src/dataDisplay/personPanel/__test__/personPanelDetailsActionButton.test.js
+++ b/src/dataDisplay/personPanel/__test__/personPanelDetailsActionButton.test.js
@@ -3,9 +3,9 @@
  * npx jest ./src/dataDisplay/personPanel/__test__/personPanelDetailsActionButton.test.js
  */
 import React from 'react';
-import PersonPanelDetailsActionButton from '../personPanelDetailsActionButton';
-import mountWithTheme from '../../../testUtils/enzymeHelpers';
-import { ENTER_KEY_CODE } from '../../../global/constants';
+import PersonPanelDetailsActionButton from '../personPanelDetailsActionButton.jsx';
+import mountWithTheme from '../../../testUtils/enzymeHelpers.jsx';
+import KeyCode from '../../../global/keyCode.js';
 
 describe('<personPanelDetailsActionButton />', () => {
     const props = {
@@ -132,7 +132,7 @@ describe('<personPanelDetailsActionButton />', () => {
             />,
         );
 
-        wrapper.find('PersonPanelDetailsActionButton').props().onKeyDown({ keyCode: ENTER_KEY_CODE });
+        wrapper.find('PersonPanelDetailsActionButton').props().onKeyDown({ keyCode: KeyCode.Enter });
 
         expect(props.onKeyDown).toHaveBeenCalledTimes(1);
     });

--- a/src/dataDisplay/personPanel/personPanelSummary.jsx
+++ b/src/dataDisplay/personPanel/personPanelSummary.jsx
@@ -14,13 +14,14 @@ import {
     GENDER_PROP_TYPE,
     RECORD_TYPE_COLOR,
     RECORD_TYPE_PROP_TYPE,
-} from './personPanelConstants';
-import { ENTER_KEY_CODE, UI_CLASS_NAME } from '../../global/constants';
+} from './personPanelConstants.js';
+import KeyCode from '../../global/keyCode.js';
+import { UI_CLASS_NAME } from '../../global/constants.js';
 import Grid from '../../layout/grid';
 import Image from '../image';
-import makeStyles from '../../styles/makeStyles';
-import PersonContactInfo from '../personContactInfo/personContactInfo';
-import Typography from '../typography/typography';
+import makeStyles from '../../styles/makeStyles.js';
+import PersonContactInfo from '../personContactInfo/personContactInfo.jsx';
+import Typography from '../typography/typography.jsx';
 
 const propTypes = {
     /**
@@ -489,7 +490,7 @@ function PersonPanelSummary(props) {
     };
 
     const onKeyDown = (event) => {
-        if (event.keyCode === ENTER_KEY_CODE) {
+        if (event.keyCode === KeyCode.Enter) {
             onClickProp(event);
         }
     };

--- a/src/global/constants.js
+++ b/src/global/constants.js
@@ -1,8 +1,3 @@
-export const BACKSPACE_KEY_CODE = 8; // TODO: We should consider an enum here for all the key codes of interest
-export const DOT_KEY_CODE = 190;
-export const ENTER_KEY_CODE = 13;
-export const MINUS_KEY_CODE = 189;
-
 export const UI_CLASS_NAME = 'cmui';
 
 export const BEM_APP_BAR = 'app_bar';

--- a/src/global/constants.js
+++ b/src/global/constants.js
@@ -1,3 +1,4 @@
+export const BACKSPACE_KEY_CODE = 8; // TODO: We should consider an enum here for all the key codes of interest
 export const DOT_KEY_CODE = 190;
 export const ENTER_KEY_CODE = 13;
 export const MINUS_KEY_CODE = 189;

--- a/src/global/keyCode.js
+++ b/src/global/keyCode.js
@@ -1,0 +1,48 @@
+// See https://www.educba.com/javascript-keycodes/ for a list of commonly used key codes
+
+/*
+enum KeyCode {
+    Backspace = 8,
+    Ctrl = 7,
+    Dot = 190,
+    Enter = 13,
+    LeftArrow = 37,
+    Letter_A = 65,
+    Letter_C = 67,
+    Letter_V = 86,
+    Letter_X = 88,
+    Letter_Y = 89,
+    Letter_Z = 90,
+    Minus = 189,
+    NormalNumber_0 = 48,
+    NormalNumber_9 = 57,
+    NumberPad_0 = 96,
+    NumberPad_9 = 105,
+    RightArrow = 39,
+    Tab = 9,
+}
+*/
+
+// Poor Man's JS Enum; having trouble with TS
+const KeyCode = Object.freeze({
+    Backspace: 8,
+    Ctrl: 7,
+    Dot: 190,
+    Enter: 13,
+    LeftArrow: 37,
+    Letter_A: 65,
+    Letter_C: 67,
+    Letter_V: 86,
+    Letter_X: 88,
+    Letter_Y: 89,
+    Letter_Z: 90,
+    Minus: 189,
+    NormalNumber_0: 48,
+    NormalNumber_9: 57,
+    NumberPad_0: 96,
+    NumberPad_9: 105,
+    RightArrow: 39,
+    Tab: 9,
+});
+
+export default KeyCode;

--- a/src/inputs/input/input.jsx
+++ b/src/inputs/input/input.jsx
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Icon from '../../dataDisplay/icon';
 import {
+    BACKSPACE_KEY_CODE,
     DOT_KEY_CODE,
     MINUS_KEY_CODE,
 } from '../../global/constants';
@@ -229,7 +230,7 @@ const defaultProps = {
 };
 
 /**
- * The Input represents a field for storing a value. 
+ * The Input represents a field for storing a value.
  */
 class Input extends React.PureComponent {
     constructor(props) {
@@ -407,9 +408,12 @@ class Input extends React.PureComponent {
         }
 
         if (type === 'number') {
-            const shouldAllowCharacter = (event.keyCode >= 48 && event.keyCode <= 57) || // character is a digit
-                (allowDecimals && event.keyCode === DOT_KEY_CODE) || // character is the decimal separator / TODO/FIXME: some locales use comma instead of dot!
-                (allowNegativeNumbers && event.keyCode === MINUS_KEY_CODE); // character is the negative sign
+            const shouldAllowCharacter =
+                event.keyCode === BACKSPACE_KEY_CODE || // allow the backspace key
+                (event.keyCode >= 48 && event.keyCode <= 57) || // allow digits 0-9 from the "normal" number keys at the top of the keybaord
+                (event.keyCode >= 96 && event.keyCode <= 105) || // allow digits 0-9 from the numeric keypad to the left of the keyboard - https://stackoverflow.com/a/13196983/7415670
+                (allowDecimals && event.keyCode === DOT_KEY_CODE) || // allow dot as the decimal separator if `allowDecimals` is `true` / TODO/FIXME: some locales use comma instead of dot!
+                (allowNegativeNumbers && event.keyCode === MINUS_KEY_CODE); // allow minus sign if `allowNegativeNumbers` is true
 
             if (!shouldAllowCharacter) {
                 event.preventDefault();

--- a/src/inputs/input/input.jsx
+++ b/src/inputs/input/input.jsx
@@ -196,6 +196,8 @@ const KEY_CODE_LETTER_A = 65;
 const KEY_CODE_LETTER_C = 67;
 const KEY_CODE_LETTER_V = 86;
 const KEY_CODE_LETTER_X = 88;
+const KEY_CODE_LETTER_Y = 89;
+const KEY_CODE_LETTER_Z = 90;
 const KEY_CODE_NORMAL_NUMBERS_0 = 48;
 const KEY_CODE_NORMAL_NUMBERS_9 = KEY_CODE_NORMAL_NUMBERS_0 + 9;
 const KEY_CODE_NUMBER_PAD_0 = 96;
@@ -419,7 +421,9 @@ class Input extends React.PureComponent {
         }
 
         if (type === 'number') {
-            const isCtrlKey = event.ctrlKey ?? event.keyCode === KEY_CODE_CTRL_KEY;
+            const isCtrlKey = event.metaKey || // detects Apple Command key - https://stackoverflow.com/a/3922353/7415670 | https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey
+                event.ctrlKey || // CTRL key modifier flag
+                event.keyCode === KEY_CODE_CTRL_KEY; // key code signifies the CTRL key
 
             const shouldAllowCharacter =
                 event.keyCode === BACKSPACE_KEY_CODE || // allow the backspace key
@@ -432,7 +436,9 @@ class Input extends React.PureComponent {
                 (isCtrlKey && event.keyCode === KEY_CODE_LETTER_A) || // allow CTRL+A for Select All
                 (isCtrlKey && event.keyCode === KEY_CODE_LETTER_C) || // allow CTRL+C for Copy
                 (isCtrlKey && event.keyCode === KEY_CODE_LETTER_V) || // allow CTRL+V for Paste
-                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_X); // allow CTRL+X for Cut
+                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_X) || // allow CTRL+X for Cut
+                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_Y) || // allow CTRL+Y for Redo
+                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_Z); // allow CTRL+Z for Undo
 
             if (!shouldAllowCharacter) {
                 event.preventDefault();

--- a/src/inputs/input/input.jsx
+++ b/src/inputs/input/input.jsx
@@ -11,11 +11,7 @@ import InputMasked from 'react-text-mask';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Icon from '../../dataDisplay/icon';
-import {
-    BACKSPACE_KEY_CODE,
-    DOT_KEY_CODE,
-    MINUS_KEY_CODE,
-} from '../../global/constants';
+import KeyCode from '../../global/keyCode.js';
 
 const propTypes = {
     /**
@@ -189,19 +185,6 @@ const propTypes = {
         PropTypes.string,
     ]),
 };
-
-// See https://www.educba.com/javascript-keycodes/ for a list of commonly used key codes
-const KEY_CODE_CTRL_KEY = 17;
-const KEY_CODE_LETTER_A = 65;
-const KEY_CODE_LETTER_C = 67;
-const KEY_CODE_LETTER_V = 86;
-const KEY_CODE_LETTER_X = 88;
-const KEY_CODE_LETTER_Y = 89;
-const KEY_CODE_LETTER_Z = 90;
-const KEY_CODE_NORMAL_NUMBERS_0 = 48;
-const KEY_CODE_NORMAL_NUMBERS_9 = KEY_CODE_NORMAL_NUMBERS_0 + 9;
-const KEY_CODE_NUMBER_PAD_0 = 96;
-const KEY_CODE_NUMBER_PAD_9 = KEY_CODE_NUMBER_PAD_0 + 9;
 
 const defaultProps = {
     autoComplete: null,
@@ -423,22 +406,25 @@ class Input extends React.PureComponent {
         if (type === 'number') {
             const isCtrlKey = event.metaKey || // detects Apple Command key - https://stackoverflow.com/a/3922353/7415670 | https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey
                 event.ctrlKey || // CTRL key modifier flag
-                event.keyCode === KEY_CODE_CTRL_KEY; // key code signifies the CTRL key
+                event.keyCode === KeyCode.Ctrl; // key code signifies the CTRL key
 
             const shouldAllowCharacter =
-                event.keyCode === BACKSPACE_KEY_CODE || // allow the backspace key
+                event.keyCode === KeyCode.Backspace || // allow the backspace key
+                event.keyCode === KeyCode.LeftArrow || // allow left arraw
+                event.keyCode === KeyCode.RightArrow || // allow right arrow
+                event.keyCode === KeyCode.Tab || // allow tab key
                 /* eslint-disable max-len */
-                (event.keyCode >= KEY_CODE_NORMAL_NUMBERS_0 && event.keyCode <= KEY_CODE_NORMAL_NUMBERS_9) || // allow digits 0-9 from the "normal" number keys at the top of the keybaord
-                (event.keyCode >= KEY_CODE_NUMBER_PAD_0 && event.keyCode <= KEY_CODE_NUMBER_PAD_9) || // allow digits 0-9 from the numeric keypad to the left of the keyboard - https://stackoverflow.com/a/13196983/7415670
+                (event.keyCode >= KeyCode.NormalNumber_0 && event.keyCode <= KeyCode.NormalNumber_9) || // allow digits 0-9 from the "normal" number keys at the top of the keybaord
+                (event.keyCode >= KeyCode.NumberPad_0 && event.keyCode <= KeyCode.NumberPad_9) || // allow digits 0-9 from the numeric keypad to the left of the keyboard - https://stackoverflow.com/a/13196983/7415670
                 /* eslint-enable max-len */
-                (allowDecimals && event.keyCode === DOT_KEY_CODE) || // allow dot as the decimal separator if `allowDecimals` is `true` / TODO/FIXME: some locales use comma instead of dot!
-                (allowNegativeNumbers && event.keyCode === MINUS_KEY_CODE) || // allow minus sign if `allowNegativeNumbers` is true
-                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_A) || // allow CTRL+A for Select All
-                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_C) || // allow CTRL+C for Copy
-                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_V) || // allow CTRL+V for Paste
-                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_X) || // allow CTRL+X for Cut
-                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_Y) || // allow CTRL+Y for Redo
-                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_Z); // allow CTRL+Z for Undo
+                (allowDecimals && event.keyCode === KeyCode.Dot) || // allow dot as the decimal separator if `allowDecimals` is `true` / TODO/FIXME: some locales use comma instead of dot!
+                (allowNegativeNumbers && event.keyCode === KeyCode.Minus) || // allow minus sign if `allowNegativeNumbers` is true
+                (isCtrlKey && event.keyCode === KeyCode.Letter_A) || // allow CTRL+A for Select All
+                (isCtrlKey && event.keyCode === KeyCode.Letter_C) || // allow CTRL+C for Copy
+                (isCtrlKey && event.keyCode === KeyCode.Letter_V) || // allow CTRL+V for Paste
+                (isCtrlKey && event.keyCode === KeyCode.Letter_X) || // allow CTRL+X for Cut
+                (isCtrlKey && event.keyCode === KeyCode.Letter_Y) || // allow CTRL+Y for Redo
+                (isCtrlKey && event.keyCode === KeyCode.Letter_Z); // allow CTRL+Z for Undo
 
             if (!shouldAllowCharacter) {
                 event.preventDefault();

--- a/src/inputs/input/input.jsx
+++ b/src/inputs/input/input.jsx
@@ -190,6 +190,17 @@ const propTypes = {
     ]),
 };
 
+// See https://www.educba.com/javascript-keycodes/ for a list of commonly used key codes
+const KEY_CODE_CTRL_KEY = 17;
+const KEY_CODE_LETTER_A = 65;
+const KEY_CODE_LETTER_C = 67;
+const KEY_CODE_LETTER_V = 86;
+const KEY_CODE_LETTER_X = 88;
+const KEY_CODE_NORMAL_NUMBERS_0 = 48;
+const KEY_CODE_NORMAL_NUMBERS_9 = KEY_CODE_NORMAL_NUMBERS_0 + 9;
+const KEY_CODE_NUMBER_PAD_0 = 96;
+const KEY_CODE_NUMBER_PAD_9 = KEY_CODE_NUMBER_PAD_0 + 9;
+
 const defaultProps = {
     autoComplete: null,
     allowDecimals: true,
@@ -408,12 +419,20 @@ class Input extends React.PureComponent {
         }
 
         if (type === 'number') {
+            const isCtrlKey = event.ctrlKey ?? event.keyCode === KEY_CODE_CTRL_KEY;
+
             const shouldAllowCharacter =
                 event.keyCode === BACKSPACE_KEY_CODE || // allow the backspace key
-                (event.keyCode >= 48 && event.keyCode <= 57) || // allow digits 0-9 from the "normal" number keys at the top of the keybaord
-                (event.keyCode >= 96 && event.keyCode <= 105) || // allow digits 0-9 from the numeric keypad to the left of the keyboard - https://stackoverflow.com/a/13196983/7415670
+                /* eslint-disable max-len */
+                (event.keyCode >= KEY_CODE_NORMAL_NUMBERS_0 && event.keyCode <= KEY_CODE_NORMAL_NUMBERS_9) || // allow digits 0-9 from the "normal" number keys at the top of the keybaord
+                (event.keyCode >= KEY_CODE_NUMBER_PAD_0 && event.keyCode <= KEY_CODE_NUMBER_PAD_9) || // allow digits 0-9 from the numeric keypad to the left of the keyboard - https://stackoverflow.com/a/13196983/7415670
+                /* eslint-enable max-len */
                 (allowDecimals && event.keyCode === DOT_KEY_CODE) || // allow dot as the decimal separator if `allowDecimals` is `true` / TODO/FIXME: some locales use comma instead of dot!
-                (allowNegativeNumbers && event.keyCode === MINUS_KEY_CODE); // allow minus sign if `allowNegativeNumbers` is true
+                (allowNegativeNumbers && event.keyCode === MINUS_KEY_CODE) || // allow minus sign if `allowNegativeNumbers` is true
+                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_A) || // allow CTRL+A for Select All
+                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_C) || // allow CTRL+C for Copy
+                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_V) || // allow CTRL+V for Paste
+                (isCtrlKey && event.keyCode === KEY_CODE_LETTER_X); // allow CTRL+X for Cut
 
             if (!shouldAllowCharacter) {
                 event.preventDefault();

--- a/src/inputs/prompt/prompt.jsx
+++ b/src/inputs/prompt/prompt.jsx
@@ -5,8 +5,8 @@ import {
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ENTER_KEY_CODE } from '../../global/constants';
-import withStyles from '../../styles/withStyles';
+import KeyCode from '../../global/keyCode.js';
+import withStyles from '../../styles/withStyles.js';
 
 const propTypes = {
     children: PropTypes.oneOfType([
@@ -211,7 +211,7 @@ class Prompt extends React.Component {
 
         if (isFunction(onKeyDown)) {
             onKeyDown(event);
-        } else if (event.keyCode === ENTER_KEY_CODE) {
+        } else if (event.keyCode === KeyCode.Enter) {
             this.onClick();
         }
     }

--- a/src/inputs/radio/radio.jsx
+++ b/src/inputs/radio/radio.jsx
@@ -9,9 +9,9 @@ import {
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ENTER_KEY_CODE } from '../../global/constants';
-import RadioItem from './radioItem';
-import withStyles from '../../styles/withStyles';
+import KeyCode from '../../global/keyCode.js';
+import RadioItem from './radioItem.jsx';
+import withStyles from '../../styles/withStyles.js';
 
 const propTypes = {
     align: PropTypes.oneOf(['left', 'right']),
@@ -349,7 +349,7 @@ class Radio extends React.Component {
             pill,
         } = this.props;
 
-        if (event.keyCode === ENTER_KEY_CODE) {
+        if (event.keyCode === KeyCode.Enter) {
             const newValue = this.setIsChecked(idArg);
             const isNotDisabled = !disable && !disabled;
 

--- a/src/navigation/a/a.jsx
+++ b/src/navigation/a/a.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import React, {
     useCallback,
 } from 'react';
-import { ENTER_KEY_CODE } from '../../global/constants';
-import makeStyles from '../../styles/makeStyles';
+import KeyCode from '../../global/keyCode.js';
+import makeStyles from '../../styles/makeStyles.js';
 
 const propTypes = {
     children: PropTypes.node,
@@ -80,7 +80,7 @@ function A(props) {
         if (!isDisabled) {
             if (isFunction(onKeyDownProp)) {
                 onKeyDownProp(event);
-            } else if (event.keyCode === ENTER_KEY_CODE) {
+            } else if (event.keyCode === KeyCode.Enter) {
                 onClick();
             }
         }


### PR DESCRIPTION
**[Bug AB#66203](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/66203) | [My Ministries > Serving Opps] - User cannot click on the checkbox to edit the venue Capacity, when creating a new SO**

Fixes the issues of not being able to use Backspace and the numeric keypad in `<Input type="number">` components.
Also restores usage of common keyboard shortcuts, including:
* CTRL+A for Select All
* CTRL+C for Copy
* CTRL+V for Paste
* CTRL+X for Cut

This accidentally regressed in #353; we were a bit overzealous in disallowing possibly invalid keystrokes in the number input!
Sorry 'bout that y'all, it was an accident!