### PR TITLE
[dev] Bug AB#68147 `<Checkbox>`es disabled with `disable` can be still be clicked

### DIFF
--- a/src/inputs/checkbox/checkbox.jsx
+++ b/src/inputs/checkbox/checkbox.jsx
@@ -115,17 +115,24 @@ class Checkbox extends React.Component {
     }
 
     onClick(event) {
-        const { disabled, id, onChange } = this.props;
+        const {
+            disable,
+            disabled,
+            id,
+            onChange,
+        } = this.props;
+
         const { isChecked } = this.state;
 
-        if (!disabled) {
+        const isDisabled = disabled || disable;
+
+        if (!isDisabled) {
             if (isFunction(onChange)) {
                 onChange(id, !isChecked, event);
             } else {
                 this.setState({
                     isChecked: !isChecked,
                 }, () => {
-                    // eslint-disable-next-line no-underscore-dangle
                     this.checkbox.current.checked = !isChecked;
                 });
             }


### PR DESCRIPTION
Defect with the `<Checkbox>` component noticed while troubleshooting the following:

**[Bug AB#68147](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/68147) | [Connection Cards > Follow Ups > Entries] - User is able to check and or uncheck disabled fields of questions in My follow Ups task's entry, in the Person Record drawer**

This fix is _NOT_ required the fix the HC Bug (which was addressed in https://github.com/saddlebackdev/church-management/pull/6085 by switching to use `disabled` instead of `disable`).  But it seems like something we _should_ fix.