### PR TITLE
[dev] Related to PBI AB#69478 - Add `error` prop support for `<Select>` component

### DIFF
--- a/docs/src/inputs/select/devSandbox/devSandbox.jsx
+++ b/docs/src/inputs/select/devSandbox/devSandbox.jsx
@@ -10,6 +10,7 @@ import ExampleClearableSelect from '../examples/exampleClearableSelect';
 import ExampleCreatableSelect from '../examples/exampleCreatableSelect';
 import ExampleCreatableAdvancedSelect from '../examples/exampleCreatableAdvancedSelect';
 import ExampleDisableSelect from '../examples/exampleDisableSelect';
+import ExampleErrorSelect from '../examples/exampleErrorSelect';
 import ExampleLabelSelect from '../examples/exampleLabelSelect';
 import ExampleMultipleSelect from '../examples/exampleMultipleSelect';
 import ExampleRequiredSelect from '../examples/exampleRequiredSelect';
@@ -65,10 +66,23 @@ function ElementsSelect() {
                     </Example>
 
                     <Heading
+                        anchorLink="select-error"
+                        variant="h2"
+                    >
+                        Select with a Validation Error
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!../examples/exampleErrorSelect').default}
+                    >
+                        <ExampleErrorSelect />
+                    </Example>
+
+                    <Heading
                         anchorLink="select-disable"
                         variant="h2"
                     >
-                        Disable Select
+                        Disabled Select
                     </Heading>
 
                     <Example

--- a/docs/src/inputs/select/examples/exampleErrorSelect.jsx
+++ b/docs/src/inputs/select/examples/exampleErrorSelect.jsx
@@ -1,0 +1,26 @@
+import { isEmpty } from 'lodash';
+import React, { useState } from 'react';
+import {
+    Select,
+} from 'react-cm-ui';
+import { options } from '../constants';
+
+function ExampleErrorSelect() {
+    const [selectedValue, setOption] = useState({});
+
+    return (
+        <Select
+            error="This is a validation error message"
+            id="block--select_id"
+            label="Select Option"
+            onChange={setOption}
+            options={options}
+            placeholder="Select"
+            required
+            tabIndex={0}
+            value={!isEmpty(selectedValue) ? selectedValue : null}
+        />
+    );
+}
+
+export default ExampleErrorSelect;

--- a/src/inputs/input/input.jsx
+++ b/src/inputs/input/input.jsx
@@ -55,7 +55,6 @@ const propTypes = {
         PropTypes.bool,
         PropTypes.string,
     ]),
-    forwardedRef: PropTypes.shape({}).isRequired,
     /**
      * An input can take on the size of its container.
      */

--- a/src/inputs/select/select.jsx
+++ b/src/inputs/select/select.jsx
@@ -3,6 +3,7 @@ import {
     has,
     isEmpty,
     isFunction,
+    isString,
     map,
     noop,
     size,
@@ -62,6 +63,13 @@ const propTypes = {
     * Supply dropdown menu style
     */
     dropdownMenuStyle: PropTypes.shape({}),
+    /**
+     * Indicates that the Select has an error.
+     */
+    error: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+    ]),
     /**
      * A Select will be resized to its parent container's width.
      */
@@ -148,6 +156,7 @@ const defaultProps = {
     className: null,
     clearable: false,
     creatable: false,
+    error: null,
     disable: false,
     disabled: false,
     dropdownMenuContainerStyle: null,
@@ -225,6 +234,7 @@ const CustomCreatableSelect = (props) => (
 const useStyles = makeStyles((theme) => {
     const {
         palette: p,
+        spacing,
         typography,
     } = theme;
 
@@ -307,6 +317,12 @@ const useStyles = makeStyles((theme) => {
                 opacity: 1,
             },
         },
+        errorMessage: {
+            color: p.error.main,
+            fontSize: typography.pxToRem(14),
+            marginTop: spacing(0.5),
+        },
+        hasError: {},
         isFluid: {},
         isUnderlined: {},
         label: {
@@ -366,6 +382,9 @@ const useStyles = makeStyles((theme) => {
                 '& .Select-input:focus': {
                     outline: 'none',
                 },
+            },
+            '&$hasError .Select-control': {
+                borderColor: p.error.main,
             },
             '& .is-searchable.is-open > .Select-control': {
                 cursor: 'text',
@@ -759,6 +778,7 @@ const Select = React.forwardRef(function Select(props, ref) {
         dropdownMenuStyle,
         dropdownMenuMaxHeight,
         dropdownMenuMinHeight,
+        error,
         fluid: isFluid,
         id,
         label,
@@ -946,6 +966,7 @@ const Select = React.forwardRef(function Select(props, ref) {
         classes.root,
         className,
         {
+            [classes.hasError]: !!error,
             [classes.isFluid]: isFluid,
             [classes.isUnderlined]: isUnderlined,
         },
@@ -1049,6 +1070,11 @@ const Select = React.forwardRef(function Select(props, ref) {
             >
                 {isCreatable && CustomCreatableSelect}
             </ReactSelectComponent>
+            {isString(error) && !!error && (
+                <p className={classes.errorMessage}>
+                    {error}
+                </p>
+            )}
         </div>
     );
 });


### PR DESCRIPTION
**[Product Backlog Item AB#69478](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/69478) | [B.2.1.0] - Ability to submit a form entry from a web page _[Submitting a form via web with people required fields]_**

As a part of this work, for improved form validation UI/UX on the public facing Connection Form, I am enhancing React CM UI `<Select>` component to add support for the `error` prop present in most of our other input components.

![image](https://user-images.githubusercontent.com/4349658/163585491-aa853f76-bd4e-4f8d-b7e0-515842a3213c.png)


