### PR TITLE
[dev] AB#92442 [React Library] Refactor UI Library for Dropdown Menus and Dropdown Buttons

### DIFF
--- a/src/inputs/dropdownButton/dropdownButton.jsx
+++ b/src/inputs/dropdownButton/dropdownButton.jsx
@@ -11,7 +11,9 @@ import {
     VariantType,
 } from '../button/models';
 import Button from '../button';
-import DropdownMenu from '../dropdownMenu/dropdownMenu';
+import DropdownMenu, {
+    propTypes as dropdownMenuPropTypes,
+} from '../dropdownMenu/dropdownMenu';
 import DropdownMenuDivider from '../dropdownMenu/dropdownMenuDivider';
 import DropdownMenuHeading from '../dropdownMenu/dropdownMenuHeading';
 import DropdownMenuOption from '../dropdownMenu/dropdownMenuOption';
@@ -64,6 +66,12 @@ const propTypes = {
      * A Dropdown Button can be disabled.
      */
     disabled: PropTypes.bool,
+    /**
+     * Props to control the DropdownMenu used by the DropdownButton.
+     */
+    dropdownMenuProps: PropTypes.shape({
+        ...dropdownMenuPropTypes,
+    }),
     /**
      * The Dropown Button will be resized to its parent container's width. (Using v1 Button)
      */
@@ -188,6 +196,7 @@ const defaultProps = {
     designVersion: 1,
     disable: false,
     disabled: false,
+    dropdownMenuProps: undefined,
     fluid: false,
     fullWidth: false,
     icon: false,
@@ -234,6 +243,7 @@ function DropdownButton(props) {
         designVersion,
         disable,
         disabled,
+        dropdownMenuProps,
         fluid,
         fullWidth,
         id,
@@ -372,6 +382,8 @@ function DropdownButton(props) {
                 onToggleOpen={onMenuToggle}
                 getParentContainer={getParentContainer}
                 optionsTheme={optionsTheme}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...dropdownMenuProps}
             >
                 {children}
             </DropdownMenu>

--- a/src/inputs/dropdownMenu/dropdownMenu.jsx
+++ b/src/inputs/dropdownMenu/dropdownMenu.jsx
@@ -2,6 +2,7 @@ import {
     debounce,
     get,
     isFunction,
+    isNil,
 } from 'lodash';
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -15,9 +16,10 @@ import {
 } from './dropdownMenuConstants';
 import makeStyles from '../../styles/makeStyles';
 
-const propTypes = {
+export const propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
+    horizontalAlign: PropTypes.string,
     id: PropTypes.string,
     isOpen: PropTypes.bool.isRequired,
     getParentContainer: PropTypes.func,
@@ -39,6 +41,7 @@ const propTypes = {
 const defaultProps = {
     optionsTheme: 'dark',
     className: undefined,
+    horizontalAlign: undefined,
     id: undefined,
     style: undefined,
     getParentContainer: undefined,
@@ -142,6 +145,7 @@ function DropdownMenu(props) {
         children,
         className,
         getParentContainer,
+        horizontalAlign,
         id,
         isOpen,
         optionsTheme,
@@ -182,8 +186,19 @@ function DropdownMenu(props) {
             bottomBias,
         } = dropdownMenuObj;
 
-        const menuXPosition = isInRight ? 'left' : 'right';
+        let menuXPosition = isInRight ? 'left' : 'right';
         let menuYPosition = topBias < bottomBias ? 'top' : 'bottom';
+
+        /**
+         * allow horizontal alignment to be overridden by the prop
+         */
+        if (!isNil(horizontalAlign)) {
+            if (horizontalAlign === 'left' && isInRight) {
+                menuXPosition = 'left';
+            } else if (horizontalAlign === 'right' || !isInRight) {
+                menuXPosition = 'right';
+            }
+        }
 
         if (isInBottom || bottomBias < 0) {
             menuYPosition = 'top';
@@ -230,7 +245,7 @@ function DropdownMenu(props) {
         onDropdownMenuReposition();
 
         return () => {
-            if (isOpen) {
+            if (!isOpen) {
                 window.removeEventListener('resize', debounceDropdownMenuReposition);
                 window.removeEventListener('scroll', debounceDropdownMenuReposition);
                 document.removeEventListener('click', onClickOutside);


### PR DESCRIPTION
This fixes a bug in allowing the `DropdownMenu` inside the `DropdownButton` to automatically close when the page is clicked outside of the button. It also adds a couple of props to allow overriding the horizontal positioning of the `DropdownMenu` to accommodate some updated designs that have right-aligned menus.