### PR TITLE
[dev] [No Bug\PBI] Prevent crash in Dropdown Menu component

### DIFF
--- a/src/inputs/dropdownMenu/dropdownMenu.jsx
+++ b/src/inputs/dropdownMenu/dropdownMenu.jsx
@@ -224,7 +224,7 @@ function DropdownMenu(props) {
     useEffect(() => {
         function onClickOutside(event) {
             const parentContainer = dropdownMenuRef.current;
-            const containsTarget = parentContainer.contains(event.target);
+            const containsTarget = parentContainer?.contains(event.target) ?? false;
 
             if (
                 !containsTarget ||

--- a/src/inputs/dropdownMenu/dropdownMenu.jsx
+++ b/src/inputs/dropdownMenu/dropdownMenu.jsx
@@ -224,7 +224,7 @@ function DropdownMenu(props) {
     useEffect(() => {
         function onClickOutside(event) {
             const parentContainer = dropdownMenuRef.current;
-            const containsTarget = parentContainer?.contains(event.target) ?? false;
+            const containsTarget = !isNil(parentContainer) && parentContainer.contains(event.target);
 
             if (
                 !containsTarget ||


### PR DESCRIPTION
Add defensive check on `parentContainer` before de-referencing it to call `contains()` method in `onClickOutside()` function, which can cause a runtime error if it's nullish.

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/55296485-3153-4d69-aa24-d7a034c22e37)

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/dadb3fdb-0cce-4a1f-bc4e-e4e3b6222fcf)
