### PR TITLE
[dev] [No Bug/PBI] Add `suppressBackgroundImage` prop to `<Image>` component

### DIFF
--- a/docs/src/app/navigationConstants.js
+++ b/docs/src/app/navigationConstants.js
@@ -137,6 +137,18 @@ export const navigationItems = [
                     {
                         component: 'image',
                         label: 'Image',
+                        levelFour: [
+                            {
+                                component: 'devSandbox/index.js',
+                                label: 'Dev Sandbox',
+                                path: 'dev-sandbox',
+                            },
+                            {
+                                component: 'api/index.js',
+                                label: 'API',
+                                path: 'api',
+                            },
+                        ],
                         path: 'image',
                     },
                     {

--- a/docs/src/dataDisplay/image/api/api.jsx
+++ b/docs/src/dataDisplay/image/api/api.jsx
@@ -1,0 +1,29 @@
+import {
+    camelCase,
+} from 'lodash';
+import React from 'react';
+import ComponentApi from '../../../global/componentApi';
+import Main from '../../../global/main';
+/* eslint-disable import/no-named-default, import/extensions, import/no-unresolved */
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!@saddlebackchurch/react-cm-ui/dataDisplay/image/image';
+/* eslint-enable import/no-named-default, import/extensions, import/no-unresolved */
+
+function DocsApi() {
+    const {
+        displayName,
+    } = rootDoc;
+
+    return (
+        <Main page={camelCase(displayName)}>
+            <Main.Content>
+                <ComponentApi
+                    docs={[
+                        rootDoc,
+                    ]}
+                />
+            </Main.Content>
+        </Main>
+    );
+}
+
+export default DocsApi;

--- a/docs/src/dataDisplay/image/api/index.js
+++ b/docs/src/dataDisplay/image/api/index.js
@@ -1,0 +1,1 @@
+export { default } from './api';

--- a/docs/src/dataDisplay/image/devSandbox/devSandbox.jsx
+++ b/docs/src/dataDisplay/image/devSandbox/devSandbox.jsx
@@ -1,0 +1,72 @@
+import {
+    Typography,
+} from '@saddlebackchurch/react-cm-ui'; // eslint-disable-line import/no-unresolved
+import {
+    camelCase,
+} from 'lodash';
+import React from 'react';
+import Example from '../../../global/example';
+import ExampleAvatarImages from './examples/exampleAvatarImages';
+import ExampleImageSizes from './examples/exampleImageSizes';
+import Heading from '../../../global/heading';
+import Main from '../../../global/main';
+import MarkdownContainer from '../../../global/markdownContainer';
+/* eslint-disable import/no-named-default, import/extensions, import/no-unresolved */
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!@saddlebackchurch/react-cm-ui/dataDisplay/image/image';
+/* eslint-enable import/no-named-default, import/extensions, import/no-unresolved */
+
+function DocsImageSandbox() {
+    const {
+        description,
+        displayName,
+    } = rootDoc;
+
+    return (
+        <Main page={camelCase(displayName)}>
+            <Main.Content>
+                <MarkdownContainer>
+                    <Typography
+                        className="description"
+                        variant="body1"
+                    >
+                        {description}
+                    </Typography>
+
+                    {/**
+                     * Avatar Images
+                     */}
+                    <Heading
+                        anchorLink="avatar-images"
+                        variant="h2"
+                    >
+                        Avatar Images
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!./examples/exampleAvatarImages').default} // eslint-disable-line import/no-unresolved, import/extensions
+                    >
+                        <ExampleAvatarImages />
+                    </Example>
+
+                    {/**
+                     * Image Sizes
+                     */}
+                    <Heading
+                        anchorLink="image-sizes"
+                        variant="h2"
+                    >
+                        Image Sizes
+                    </Heading>
+
+                    <Example
+                        rawCode={require('!!raw-loader!./examples/exampleImageSizes').default} // eslint-disable-line import/no-unresolved, import/extensions
+                    >
+                        <ExampleImageSizes />
+                    </Example>
+                </MarkdownContainer>
+            </Main.Content>
+        </Main>
+    );
+}
+
+export default DocsImageSandbox;

--- a/docs/src/dataDisplay/image/devSandbox/examples/exampleAvatarImages.jsx
+++ b/docs/src/dataDisplay/image/devSandbox/examples/exampleAvatarImages.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+    Image,
+} from '@saddlebackchurch/react-cm-ui';
+import sampleImage from '../../../../images/marty-mcfly.jpg';
+
+export default function ExampleAvatarImages() {
+    return (
+        <div>
+            <Image type="person" />
+            <br />
+            <br />
+            <Image type="user" />
+            <br />
+            <br />
+            <Image type="person" src={sampleImage} />
+            <br />
+            <br />
+            <Image type="user" src={sampleImage} />
+            <br />
+            <br />
+            <Image type="person" name="Marty McFly" />
+            <br />
+            <br />
+            <Image type="user" name="Marty McFly" />
+            <br />
+            <br />
+            {/*
+                Test Name AND Image Source
+                Shouldn't render image AND initials ... only image :-)
+            */}
+            <Image type="person" name="Marty McFly" src={sampleImage} />
+            <br />
+            <br />
+            <Image type="user" name="Marty McFly" src={sampleImage} />
+        </div>
+    );
+}

--- a/docs/src/dataDisplay/image/devSandbox/examples/exampleImage.jsx
+++ b/docs/src/dataDisplay/image/devSandbox/examples/exampleImage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import {
+    Image,
+} from '@saddlebackchurch/react-cm-ui';
+import sampleImage from '../../../../images/marty-mcfly.jpg';
+
+export default function ExampleImage() {
+    return (
+        <Image src={sampleImage} />
+    );
+}

--- a/docs/src/dataDisplay/image/devSandbox/examples/exampleImageSizes.jsx
+++ b/docs/src/dataDisplay/image/devSandbox/examples/exampleImageSizes.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {
+    Image,
+} from '@saddlebackchurch/react-cm-ui';
+import sampleImage from '../../../../images/marty-mcfly.jpg';
+
+export default function ExampleImageSizes() {
+    return (
+        <div>
+            <Image src={sampleImage} size={100} />
+            <br />
+            <br />
+            <Image type="user" size={44} name="Marty McFly" />
+            <br />
+            <br />
+            <Image type="user" size={66} src={sampleImage} />
+            <br />
+            <br />
+            <Image type="user" size={22} />
+            <br />
+            <br />
+            <Image type="user" size={44} />
+            <br />
+            <br />
+            <Image type="user" size={66} />
+            <br />
+            <br />
+            <Image type="user" size={88} />
+        </div>
+    );
+}

--- a/docs/src/dataDisplay/image/devSandbox/index.js
+++ b/docs/src/dataDisplay/image/devSandbox/index.js
@@ -1,0 +1,1 @@
+export { default } from './devSandbox';

--- a/docs/src/dataDisplay/image/image.jsx
+++ b/docs/src/dataDisplay/image/image.jsx
@@ -1,226 +1,70 @@
-import 'images/marty-mcfly.jpg';
-
 import {
-    Card,
-    Header,
-    Image,
-} from '@saddlebackchurch/react-cm-ui';
+    Typography,
+} from '@saddlebackchurch/react-cm-ui'; // eslint-disable-line import/no-unresolved
+import {
+    camelCase,
+} from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
-import Highlighter from '../../global/highlighter';
+import ComponentVersionIdentifier from '../../global/componentVersionIdentifier';
+import Example from '../../global/example';
+import ExampleImage from './devSandbox/examples/exampleImage';
+import Heading from '../../global/heading';
 import Main from '../../global/main';
-import TableProps from '../../global/tableProps';
+import MarkdownContainer from '../../global/markdownContainer';
+/* eslint-disable import/no-named-default, import/extensions, import/no-unresolved */
+import { default as rootDoc } from '!!@advclb/react-docgen-loader!@saddlebackchurch/react-cm-ui/dataDisplay/image/image';
+/* eslint-enable import/no-named-default, import/extensions, import/no-unresolved */
 
-const imageSample = `import React from 'react';
-import { Image } from '@saddlebackchurch/react-cm-ui';
+const propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string,
+    }).isRequired,
+};
 
-export default class ImageSample extends React.Component {
-
-    render() {
-        return (
-            <Image src="images/marty-mcfly.jpg" />
-        );
-    }
-
-}`;
-
-const avatarSample = `import React from 'react';
-import { Image } from '@saddlebackchurch/react-cm-ui';
-
-export default class AvatarSample extends React.Component {
-
-    render() {
-        const MARTY_MCFLY_IMAGE_SRC = 'images/marty-mcfly.jpg';
-
-        return (
-            <div>
-                <Image type="person" /><br /><br />
-                <Image type="user" /><br /><br />
-                <Image type="person" src={MARTY_MCFLY_IMAGE_SRC} /><br /><br />
-                <Image type="user" src={MARTY_MCFLY_IMAGE_SRC} /><br /><br />
-                <Image type="person" name="Marty McFly" /><br /><br />
-                <Image type="user" name="Marty McFly" /><br /><br />
-                {/*
-                    Test Name AND Image Source
-                    Shouldn't render image AND initials ... only image :-)
-                */}
-                <Image type="person" name="Marty McFly" src={MARTY_MCFLY_IMAGE_SRC} /><br /><br />
-                <Image type="user" name="Marty McFly" src={MARTY_MCFLY_IMAGE_SRC} />
-            </div>
-        );
-    }
-}`;
-
-const sizeSample = `import React from 'react';
-import { Image } from '@saddlebackchurch/react-cm-ui';
-
-export default class SizeSample extends React.Component {
-
-    render() {
-        const MARTY_MCFLY_IMAGE_SRC = '/images/marty-mcfly.jpg';
-
-        return (
-            <div>
-                <Image src={MARTY_MCFLY_IMAGE_SRC} size={100} /><br /><br />
-                <Image type="user" size={44} name="Marty McFly" /><br /><br />
-                <Image type="user" size={66} src={MARTY_MCFLY_IMAGE_SRC} /><br /><br />
-                <Image type="user" size={22} /><br /><br />
-                <Image type="user" size={44} /><br /><br />
-                <Image type="user" size={66} /><br /><br />
-                <Image type="user" size={88} />
-            </div>
-        );
-    }
-}`;
-
-const props = [
-    {
-        name: 'as',
-        type: 'enum',
-        default: 'img',
-        description: 'An element type to render as.',
-        allowedTypes: 'div, img',
-    }, {
-        name: 'border',
-        type: 'number',
-        default: '',
-        description: 'Determines width of border, If set to true border width is set to 1. Also, setting it to number would set same border width',
-        allowedTypes: 'bool, number',
-    }, {
-        name: 'borderInverse',
-        type: 'bool',
-        default: '',
-        description: 'If set to true, border color set to white',
-        allowedTypes: '',
-    }, {
-        name: 'className',
-        type: 'string',
-        default: '',
-        description: 'Additional classes.',
-        allowedTypes: '',
-    }, {
-        name: 'size',
-        type: 'number',
-        default: '',
-        description: 'Size of Image.',
-        allowedTypes: '',
-    }, {
-        name: 'src',
-        type: 'string',
-        default: '',
-        description: 'Path to image file.',
-        allowedTypes: '',
-    }, {
-        name: 'style',
-        type: 'object',
-        default: '',
-        description: 'Supply any inline styles to the Image or Image\'s container.',
-        allowedTypes: '',
-    }, {
-        name: 'type',
-        type: 'enum',
-        default: '',
-        description: 'An Image can be shown as a circular & square avatar',
-        allowedTypes: 'person, user',
+function DocsImage({
+    location: {
+        pathname,
     },
-];
+}) {
+    const {
+        description,
+        displayName,
+    } = rootDoc;
 
-const MARTY_MCFLY_IMAGE_SRC = '/images/marty-mcfly.jpg';
-
-export default function ElementsImage() {
     return (
-        <Main page="headers">
+        <Main page={camelCase(displayName)}>
             <Main.Content>
-                <Card>
-                    <Header size="large">Props</Header>
+                <MarkdownContainer>
+                    <Typography
+                        className="description"
+                        variant="body1"
+                    >
+                        {description}
+                    </Typography>
 
-                    <TableProps props={props} />
-                </Card>
+                    <Heading
+                        anchorLink="image"
+                        variant="h2"
+                    >
+                        Image
+                    </Heading>
 
-                {/* Image */}
-                <Header size="large" style={{ marginTop: '55px' }} sub>
-                    Image
-                    <Header.Subheader>
-                        An image.
-                    </Header.Subheader>
-                </Header>
+                    <Example
+                        rawCode={require('!!raw-loader!./devSandbox/examples/exampleImage').default} // eslint-disable-line import/no-unresolved, import/extensions
+                    >
+                        <ExampleImage />
+                    </Example>
+                </MarkdownContainer>
 
-                <Image src={MARTY_MCFLY_IMAGE_SRC} />
-
-                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                    {imageSample}
-                </Highlighter>
-
-                {/* Avatar */}
-                <Header size="large" style={{ marginTop: '55px' }} sub>
-                    Avatar
-                    <Header.Subheader>
-                        An image can be an avatar.
-                    </Header.Subheader>
-                </Header>
-
-                <Image type="person" />
-                <br />
-                <br />
-                <Image type="user" />
-                <br />
-                <br />
-                <Image type="person" src={MARTY_MCFLY_IMAGE_SRC} />
-                <br />
-                <br />
-                <Image type="user" src={MARTY_MCFLY_IMAGE_SRC} />
-                <br />
-                <br />
-                <Image type="person" name="Marty McFly" />
-                <br />
-                <br />
-                <Image type="user" name="Marty McFly" />
-                <br />
-                <br />
-                {/*
-                    Test Name AND Image Source
-                    Shouldn't render image AND initials ... only image :-)
-                */}
-                <Image type="person" name="Marty McFly" src={MARTY_MCFLY_IMAGE_SRC} />
-                <br />
-                <br />
-                <Image type="user" name="Marty McFly" src={MARTY_MCFLY_IMAGE_SRC} />
-
-                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                    {avatarSample}
-                </Highlighter>
-
-                {/* Size */}
-                <Header size="large" style={{ marginTop: '55px' }} sub>
-                    Size
-                    <Header.Subheader>
-                        Passing a size (number) will contrain the image by its width.
-                    </Header.Subheader>
-                </Header>
-
-                <Image src={MARTY_MCFLY_IMAGE_SRC} size={100} />
-                <br />
-                <br />
-                <Image type="user" size={44} name="Marty McFly" />
-                <br />
-                <br />
-                <Image type="user" size={66} src={MARTY_MCFLY_IMAGE_SRC} />
-                <br />
-                <br />
-                <Image type="user" size={22} />
-                <br />
-                <br />
-                <Image type="user" size={44} />
-                <br />
-                <br />
-                <Image type="user" size={66} />
-                <br />
-                <br />
-                <Image type="user" size={88} />
-
-                <Highlighter customStyle={{ marginBottom: '44px', marginTop: '44px' }}>
-                    {sizeSample}
-                </Highlighter>
+                <ComponentVersionIdentifier
+                    pathname={pathname}
+                />
             </Main.Content>
         </Main>
     );
 }
+
+DocsImage.propTypes = propTypes;
+
+export default DocsImage;

--- a/src/dataDisplay/image/__test__/image.test.js
+++ b/src/dataDisplay/image/__test__/image.test.js
@@ -1,6 +1,6 @@
 /**
  * To run this test:
- * npx jest ./src/dataDisplay/header/__test__/header.test.js
+ * npx jest ./src/dataDisplay/image/__test__/image.test.js
  */
 
 import React from 'react';
@@ -25,8 +25,8 @@ describe('<Image />', () => {
         expect(screen.queryByTestId('cmui-image')).toBeInTheDocument();
     });
 
-    describe('avatar', () => {
-        it('default person: should show with person icon when \'src\' and \'name\' is undefined', () => {
+    describe('Avatars', () => {
+        it('default person: should show with person icon when \'src\' and \'name\' are undefined', () => {
             render(
                 <Image
                     type="person"
@@ -37,7 +37,7 @@ describe('<Image />', () => {
             expect(screen.queryByText('This person has no image')).toBeInTheDocument();
         });
 
-        it('default user: should show with user icon when \'src\' and \'name\' is undefined', () => {
+        it('default user: should show with user icon when \'src\' and \'name\' are undefined', () => {
             render(
                 <Image
                     type="user"
@@ -46,6 +46,45 @@ describe('<Image />', () => {
 
             expect(screen.queryByTestId('cmui-icon-user')).toBeInTheDocument();
             expect(screen.queryByText('This user has no image')).toBeInTheDocument();
+        });
+    });
+
+    describe('CSS background image', () => {
+        it('adds CSS background image by default', () => {
+            const imageProps = {
+                ...props,
+                alt: 'Marty McFly',
+            };
+
+            render(
+                <Image
+                    {...imageProps}
+                />,
+            );
+
+            const image = screen.getByAltText(imageProps.alt);
+            expect(image).toBeInTheDocument();
+            const styles = image.getAttribute('style');
+            expect(styles).toContain(`background-image: url(${props.src});`);
+        });
+
+        it('does not add CSS background image if \'suppressBackgroundImage\' prop is set to \'true\'', () => {
+            const imageProps = {
+                ...props,
+                alt: 'Marty McFly',
+                suppressBackgroundImage: true,
+            };
+
+            render(
+                <Image
+                    {...imageProps}
+                />,
+            );
+
+            const image = screen.getByAltText(imageProps.alt);
+            expect(image).toBeInTheDocument();
+            const styles = image.getAttribute('style');
+            expect(styles).toBeNull();
         });
     });
 });

--- a/src/dataDisplay/image/image.jsx
+++ b/src/dataDisplay/image/image.jsx
@@ -4,8 +4,7 @@ import React from 'react';
 import {
     UI_CLASS_NAME,
 } from '../../global/constants';
-// eslint-disable-next-line import/extensions
-import colorStyles from '../../styles/colorExports';
+import colorStyles from '../../styles/colorExports.scss';
 import Icon from '../icon';
 import Utils from '../../utils/utils';
 
@@ -13,23 +12,86 @@ const asEnums = ['div', 'img'];
 const typeEnums = ['person', 'user'];
 
 const propTypes = {
+    /**
+     * Specify `alt` attribute content for an image rendered with element type <strong>&lt;img&gt;</strong>.
+     */
+    alt: PropTypes.string,
+    /**
+     * Specify the kind of element to use ( <strong>&lt;img&gt;</strong> or <strong>&lt;div&gt;</strong> with background image).
+     *
+     * Optional; defaults to <strong>&lt;img&gt;</strong>.
+     */
     as: PropTypes.oneOf(asEnums),
+    /**
+     * Determines whether to addd a border to the image, and, if so, its width.
+     *
+     * If set to `true` then the image will have a border with width is set to 1.
+     * If set to a number then the image will have a order with the specified width.
+     */
     border: PropTypes.oneOfType([
         PropTypes.bool,
         PropTypes.number,
     ]),
+    /**
+     * If the image has a border, and this prop is set to `true` then the image's border color will be set to white.
+     */
     borderInverse: PropTypes.bool,
+    /**
+     * Add additional class names to the image.
+     */
     className: PropTypes.string,
+    /**
+     * Assign a `data-testid` attribute to the image to help find it during UI unit testing.
+     *
+     * Consider using the `alt` prop to assign alt text to the image, and `*ByAltText()` selector methods
+     * instead of assigning a Test ID in order to find your image in unit tests.
+     *
+     * See:
+     *
+     * https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-the-wrong-query
+     *
+     * https://testing-library.com/docs/queries/about/#priority
+     */
     dataTestId: PropTypes.string,
+    /**
+     * For avatar or photo images representing a User or Person, this is the user/person's name,
+     * so his or her initials can be used as a fallback.
+     */
     name: PropTypes.string,
+    /**
+     * Size of the image.
+     */
     size: PropTypes.number,
+    /**
+     * Image source URL.
+     */
     src: PropTypes.string,
+    /**
+     * Inline styles for the image.
+     */
     style: PropTypes.shape({}),
+    /**
+     * For legacy reasons, we set the specified image url as a CSS background image on
+     * <strong>&lt;img&gt;</strong> tags, as well as setting the `src` attribute.
+     *
+     * This prop allows that behavior to be suppressed.
+     */
+    suppressBackgroundImage: PropTypes.bool,
+    /**
+     * Sets the `title` attribute for the image (e.g. to show a tooltip on hover).
+     */
     title: PropTypes.string,
+    /**
+     * For avatar images, determines whether to display a square image
+     * (`type` = `'person'`) or a circular image (`type` = `'user'`).
+     *
+     * Also determine the kind of <strong>&lt;Icon&gt;</strong> to be used as a fallback if no `src` or `name` is provided.
+     */
     type: PropTypes.oneOf(typeEnums),
 };
 
 const defaultProps = {
+    alt: undefined,
     as: 'img',
     border: undefined,
     borderInverse: undefined,
@@ -39,6 +101,7 @@ const defaultProps = {
     size: undefined,
     src: undefined,
     style: {},
+    suppressBackgroundImage: false,
     title: undefined,
     type: undefined,
 };
@@ -53,6 +116,7 @@ function Image(props) {
         name,
         size,
         src,
+        suppressBackgroundImage,
         style,
         title,
         type,
@@ -75,9 +139,11 @@ function Image(props) {
     );
 
     if (ElementType === 'img') {
+        const shouldAddBackgroundImageStyle = !suppressBackgroundImage && !!src;
+
         newStyle = {
             ...style,
-            backgroundImage: src ? `url(${src})` : null,
+            backgroundImage: shouldAddBackgroundImageStyle ? `url(${src})` : undefined,
             width: size,
         };
 


### PR DESCRIPTION
* Be able to stop `<Image>` component from adding CSS background image by specifying new prop
* Update documentation style for `<Image>` component

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/720eff42-2dd3-4bc4-bddf-5b3eb9a2ddca)

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/4aa90645-b540-4127-ad4f-b8aedcf9dd84)

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/4998ff6c-7e66-42ba-8b8a-7331440e16e4)
