### PR TITLE
[dev][hotfix/1.62.3] - Bug AB#97711 - [Connection Forms][Safari] - Public form not rendering phone number country flag icon

### DIFF
--- a/src/inputs/phoneInput/phoneInput.scss
+++ b/src/inputs/phoneInput/phoneInput.scss
@@ -56,6 +56,10 @@ $width: 65px;
         .react-phone-number-input__icon-image {
             height: 16px;
         }
+        > svg {
+            height: 100%;
+            width: 100%;
+        }
     }
     .react-phone-number-input__input {
         background-color: color(backgroundColor);


### PR DESCRIPTION
[dev][hotfix/1.62.3] - Bug [AB#97711](https://dev.azure.com/saddlebackchurch/b8a0d0bb-a4fe-48e3-9a60-2f1440145fc4/_workitems/edit/97711) - [Connection Forms][Safari] - Public form not rendering phone number country flag icon

Description
- height and width added to svg icon used inside input flag as on safari it is required for svg's to show

cm-ui doc screenshot on safari
<img width="1728" alt="Screenshot 2023-07-25 at 10 37 12" src="https://github.com/saddlebackdev/react-cm-ui/assets/44872902/3088d829-e67c-499e-b836-d6ecb5071c50">

local changes screenshot on safari
<img width="1728" alt="Screenshot 2023-07-25 at 10 36 41" src="https://github.com/saddlebackdev/react-cm-ui/assets/44872902/a298462b-631e-481b-9ed9-adef3c793525">
