### PR TITLE
[dev] [No Bug/PBI] Fix `colorExports` SCSS/CSS import in `<Image>` component

### DIFF
--- a/src/dataDisplay/image/image.jsx
+++ b/src/dataDisplay/image/image.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {
     UI_CLASS_NAME,
 } from '../../global/constants';
-import colorStyles from '../../styles/colorExports.scss';
+import colorStyles from '../../styles/colorExports'; // eslint-disable-line import/extensions, import/no-unresolved
 import Icon from '../icon';
 import Utils from '../../utils/utils';
 


### PR DESCRIPTION
It needs to not have an extension because the SCSS source file will get converted to CSS and exported as such, so we need to be able to resolve the CSS file when the component is used (e.g. within HC Admin).

Otherwise, we get this error when doing `npm install` in `church-management`:
```
ERROR in ./node_modules/@saddlebackchurch/react-cm-ui/core/dataDisplay/image/image.js
Module not found: Error: Can't resolve '../../styles/colorExports.scss' in 'C:\Projects\Saddleback\cm-clean\client\node_modules\@saddlebackchurch\react-cm-ui\core\dataDisplay\image'
 @ ./node_modules/@saddlebackchurch/react-cm-ui/core/dataDisplay/image/image.js 16:43-84
 @ ./node_modules/@saddlebackchurch/react-cm-ui/core/dataDisplay/image/index.js
 @ ./node_modules/@saddlebackchurch/react-cm-ui/core/dataDisplay/personPanel/personPanelSummary.js
 @ ./node_modules/@saddlebackchurch/react-cm-ui/core/index.js
 @ dll healthyChurchDeps
```