### PR TITLE
[dev] BUG AB#96509 - [Giving Checkout] - The "Date pickers" should disappear, if & when the user decides to tap in & enter the "Start/End Dates" manually, for a Recurring or 1-Time scheduled gifts

### DIFF
--- a/src/inputs/datePickerInput/__test__/datePickerInput.test.js
+++ b/src/inputs/datePickerInput/__test__/datePickerInput.test.js
@@ -8,6 +8,7 @@ import {
     fireEvent,
     render,
     screen,
+    waitFor,
 } from '../../../testUtils';
 import DatePickerInput from '../datePickerInput';
 
@@ -142,6 +143,38 @@ describe('<DatePickerInput />', () => {
             const onChangeDateToArg = onChangeArgObj.dateTo;
             expect(moment.isMoment(onChangeDateToArg)).toBe(true);
             expect(onChangeDateToArg.format('MM/DD/YYYY')).toEqual(newDateValue);
+        });
+    });
+
+    describe('Calendar Picker', () => {
+        it('hides when manually entering a date', async () => {
+            const {
+                getByTestId,
+                queryByTestId,
+            } = render(
+                <DatePickerInput dataTestId="date_picker_input" />,
+            );
+
+            expect(queryByTestId('date_picker_input--calendar_picker')).not.toBeInTheDocument();
+
+            const icon = getByTestId('cmui-icon-calendar');
+
+            fireEvent.click(icon);
+
+            expect(queryByTestId('date_picker_input--calendar_picker')).toBeInTheDocument();
+
+            await waitFor(() => {
+                fireEvent.change(
+                    queryByTestId('date_picker_input'),
+                    {
+                        target: {
+                            value: '01/10/2022',
+                        },
+                    },
+                );
+            });
+
+            expect(queryByTestId('date_picker_input--calendar_picker')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -15,6 +15,7 @@ import DatePickerUtils from '../../utils/datePickerUtils';
 import DateUtils from '../../utils/dateUtils';
 import Icon from '../../dataDisplay/icon';
 import Input from '../input';
+import KeyCode from '../../global/keyCode';
 import DatePickerCalendarOnClickOutside from '../datePickerCalendar/datePickerCalendarOnClickOutside';
 import withStyles from '../../styles/withStyles';
 
@@ -110,7 +111,7 @@ const propTypes = {
     ]),
 
     /**
-     * Hides the calendar picker when introducing the date manually
+     * Hides the calendar picker when entering the date manually
      */
     hideCalendarPickerOnKeyDown: PropTypes.bool,
 
@@ -445,7 +446,7 @@ class DatePickerInput extends React.PureComponent {
         } = this.props;
 
         const shouldHideCalendarPicker = hideCalendarPickerOnKeyDown ||
-            (event.keyCode === 9 || event.keyCode === 13);
+            (event.keyCode === KeyCode.Tab || event.keyCode === KeyCode.Enter);
 
         if (shouldHideCalendarPicker) {
             this.setOpen(false);

--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -108,6 +108,11 @@ const propTypes = {
     ]),
 
     /**
+     * Hides the calendar picker when introducing the date manually
+     */
+    hideCalendarPickerOnKeyDown: PropTypes.bool,
+
+    /**
      * Specify an element ID this DatePickerInput control.
      */
     id: PropTypes.oneOfType([
@@ -198,6 +203,7 @@ const defaultProps = {
     filterDates: null,
     fluid: false,
     forwardedRef: undefined,
+    hideCalendarPickerOnKeyDown: false,
     id: null,
     includeDates: null,
     label: null,
@@ -368,6 +374,7 @@ class DatePickerInput extends React.PureComponent {
         const isNotDisabled = !disable && !disabled;
 
         if (isNotDisabled) {
+            this.setOpen(true);
             this.datePickerInput.current.inputElement.focus();
         }
     }
@@ -431,7 +438,14 @@ class DatePickerInput extends React.PureComponent {
     }
 
     onInputKeyDown(event) {
-        if (event.keyCode === 9 || event.keyCode === 13) {
+        const {
+            hideCalendarPickerOnKeyDown,
+        } = this.props;
+
+        const shouldHideCalendarPicker = hideCalendarPickerOnKeyDown ||
+            (event.keyCode === 9 || event.keyCode === 13);
+
+        if (shouldHideCalendarPicker) {
             this.setOpen(false);
         }
     }

--- a/src/inputs/datePickerInput/datePickerInput.jsx
+++ b/src/inputs/datePickerInput/datePickerInput.jsx
@@ -18,6 +18,8 @@ import Input from '../input';
 import DatePickerCalendarOnClickOutside from '../datePickerCalendar/datePickerCalendarOnClickOutside';
 import withStyles from '../../styles/withStyles';
 
+const BEM_BLOCK_NAME = 'date_picker_input';
+
 const propTypes = {
     /**
      * Forces the DatePickerInput component to always show the required indicator
@@ -574,7 +576,10 @@ class DatePickerInput extends React.PureComponent {
                         attachment: 'together',
                     }]}
                     renderElement={(ref) => isCalendarOpen && (
-                        <div ref={ref}>
+                        <div
+                            ref={ref}
+                            data-testid={`${BEM_BLOCK_NAME}--calendar_picker`}
+                        >
                             <DatePickerCalendarOnClickOutside
                                 controls="dropdowns"
                                 date={date}


### PR DESCRIPTION
This PR updates the `<CalendarPickerInput />` to hide the Calendar Picker on keyboard down:

<img width="305" alt="image" src="https://github.com/saddlebackdev/react-cm-ui/assets/8116485/11112fd9-9ac0-4072-837a-795e3597d669">

_After entering the date manually_

<img width="494" alt="image" src="https://github.com/saddlebackdev/react-cm-ui/assets/8116485/f2f3b597-42d9-4a23-b38a-5780373fdcaa">
