### PR TITLE
[dev] AB#101093 [Finance > Add Account] - The required (red) asterisk signs are missing, to the right of the "Account Type & Subtype" headers titles, of the "Account Type & Subtype" drop menus in the "Add Account" modal 

### DIFF
--- a/src/inputs/selectNext/selectNext.tsx
+++ b/src/inputs/selectNext/selectNext.tsx
@@ -1,6 +1,7 @@
 import ClassNames from 'classnames';
 import {
     isFunction,
+    isEmpty,
 } from 'lodash';
 import React, {
     LegacyRef,
@@ -19,6 +20,12 @@ import {
 import makeStyles from '../../styles/makeStyles';
 
 type PropTypes = {
+    /**
+    * Forces the Select component to always show the required indicator
+    * next to the label. The default behavior (if this prop is omitted or false) is for
+    * the required field indicator to disappear once a value has been selected.
+    */
+    alwaysShowRequiredIndicator: boolean;
     /**
     * Assign a class name to the outer component.
     */
@@ -69,6 +76,10 @@ type PropTypes = {
      */
     placeholder?: string;
     /**
+     * A Select can be required
+     */
+    required?: boolean;
+    /**
      * Style modifier methods
      * A basic example can be found at the bottom of the Replacing builtins documentation.
      * https://react-select.com/advanced#replacing-builtins
@@ -86,6 +97,7 @@ type PropTypes = {
 };
 
 const defaultProps = {
+    alwaysShowRequiredIndicator: false,
     className: null,
     dropdownMenuMaxHeight: 180,
     dropdownMenuMinHeight: null,
@@ -96,6 +108,7 @@ const defaultProps = {
     onChange: null,
     options: [],
     placeholder: null,
+    required: false,
     tabIndex: -1,
     value: null,
 };
@@ -104,6 +117,7 @@ const useStyles = makeStyles((theme) => {
     const {
         // @ts-ignore
         palette: p,
+        typography,
     } = theme;
 
     const darkThemeBoxShadow = '0 4px 4px 0 rgba(0, 0, 0, 0.43)';
@@ -266,6 +280,12 @@ const useStyles = makeStyles((theme) => {
         label: {
             marginBottom: 8,
         },
+        requiredIndicator: {
+            color: p.error.main,
+            display: 'inline-block',
+            fontSize: typography.pxToRem(14),
+            marginLeft: 3,
+        },
     };
 });
 
@@ -360,6 +380,7 @@ const SelectNext = React.forwardRef(function SelectNext(
     ref: LegacyRef<HTMLDivElement>,
 ) {
     const {
+        alwaysShowRequiredIndicator,
         className,
         dropdownMenuMaxHeight,
         dropdownMenuMinHeight,
@@ -372,6 +393,7 @@ const SelectNext = React.forwardRef(function SelectNext(
         onChange: onChangeProp,
         options,
         placeholder,
+        required,
         styles,
         tabIndex,
         value,
@@ -393,6 +415,8 @@ const SelectNext = React.forwardRef(function SelectNext(
         className,
     );
 
+    const showRequiredIndicator = required && (alwaysShowRequiredIndicator || isEmpty(value));
+
     return (
         <div
             // eslint-disable-next-line react/jsx-props-no-spreading
@@ -409,6 +433,10 @@ const SelectNext = React.forwardRef(function SelectNext(
                     )}
                 >
                     {label}
+
+                    {required && showRequiredIndicator ? (
+                        <span className={classes.requiredIndicator}>*</span>
+                    ) : null}
                 </label>
             )}
 

--- a/src/inputs/selectNext/selectNext.tsx
+++ b/src/inputs/selectNext/selectNext.tsx
@@ -117,6 +117,8 @@ const useStyles = makeStyles((theme) => {
     const {
         // @ts-ignore
         palette: p,
+        // @ts-ignore
+        typography,
     } = theme;
 
     const darkThemeBoxShadow = '0 4px 4px 0 rgba(0, 0, 0, 0.43)';
@@ -282,7 +284,7 @@ const useStyles = makeStyles((theme) => {
         requiredIndicator: {
             color: p.error.main,
             display: 'inline-block',
-            fontSize: '14px',
+            fontSize: typography.pxToRem(14),
             marginLeft: 3,
         },
     };

--- a/src/inputs/selectNext/selectNext.tsx
+++ b/src/inputs/selectNext/selectNext.tsx
@@ -117,7 +117,6 @@ const useStyles = makeStyles((theme) => {
     const {
         // @ts-ignore
         palette: p,
-        typography,
     } = theme;
 
     const darkThemeBoxShadow = '0 4px 4px 0 rgba(0, 0, 0, 0.43)';
@@ -283,7 +282,7 @@ const useStyles = makeStyles((theme) => {
         requiredIndicator: {
             color: p.error.main,
             display: 'inline-block',
-            fontSize: typography.pxToRem(14),
+            fontSize: '14px',
             marginLeft: 3,
         },
     };


### PR DESCRIPTION
This PR includes fixes for:

[PBI AB#101093](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/101093) - The required asterisk (red) signs are missing, to the right of the "Account Type & Subtype" headers titles, of the "Account Type & Subtype" drop menus in the "Add Account" modal.

<img width="925" alt="Screenshot 2023-09-19 at 12 44 03" src="https://github.com/saddlebackdev/react-cm-ui/assets/8116485/fd0c55b0-cbbf-4592-a483-d80942207811">

