### PR TITLE
[dev] [No Bug/PBI] Fix improper console warning in `<ActionBarSearch>`

### DIFF
--- a/src/surfaces/actionBar/actionBarSearch.jsx
+++ b/src/surfaces/actionBar/actionBarSearch.jsx
@@ -133,12 +133,14 @@ class ActionBarSearch extends React.PureComponent {
             value,
         } = this.props;
 
-        const hasCorrectDataForSearchWithSelect = !isNil(searchWithSelect) &&
-        isArray(searchWithSelect.options) &&
-        isFunction(searchWithSelect.onChange) &&
-        ('value' in searchWithSelect);
+        const isUsingSearchWithSelect = !isNil(searchWithSelect);
 
-        if (!hasCorrectDataForSearchWithSelect) {
+        const hasCorrectDataForSearchWithSelect = isUsingSearchWithSelect &&
+            isArray(searchWithSelect.options) &&
+            isFunction(searchWithSelect.onChange) &&
+            ('value' in searchWithSelect);
+
+        if (isUsingSearchWithSelect && !hasCorrectDataForSearchWithSelect) {
             console.warn( // eslint-disable-line no-console
                 'Please provide correct props to integrate Select with action bar search. See documentation of react-cm-ui for more details.',
             );


### PR DESCRIPTION
This is a minor regression with the newer functionality in `<ActionBarSearch>` where a `<Select>` can be combined with the search input, in order to help give context to a search term (to aid certain back-end calls that require this to correctly process searches where we're not just using a full-text search powered by ElasticSearch), introduced in #452.  Some validation logic resulted in a console warning about not using this new feature correctly, even if _consumer was not using it at all!_  This change corrects that issue.