### PR TITLE
[dev] BUG AB#102385 - [Finance > Segments & Codes > Edit Code] - User should be able to nullify the "Associated HC Campus" (if they want to) of a Campus code, in the drop down menu, as it is not a required field

### DIFF
--- a/src/inputs/selectNext/selectNext.tsx
+++ b/src/inputs/selectNext/selectNext.tsx
@@ -1,7 +1,7 @@
 import ClassNames from 'classnames';
 import {
-    isFunction,
     isEmpty,
+    isFunction,
 } from 'lodash';
 import React, {
     LegacyRef,
@@ -12,6 +12,7 @@ import Select, {
     components,
     StylesConfig,
 } from 'react-select';
+import { ClearIndicatorProps } from 'react-select/dist/declarations/src/components/indicators';
 import Icon from '../../dataDisplay/icon';
 import {
     BEM_SELECT,
@@ -131,6 +132,8 @@ const useStyles = makeStyles((theme) => {
         palette: p,
         // @ts-ignore
         typography,
+        // @ts-ignore
+        spacing,
     } = theme;
 
     const darkThemeBoxShadow = '0 4px 4px 0 rgba(0, 0, 0, 0.43)';
@@ -291,10 +294,11 @@ const useStyles = makeStyles((theme) => {
                     },
                 },
                 '&--clear_icon_container': {
-                    marginRight: 11,
+                    marginRight: spacing(1),
                     alignItems: 'center',
                     display: 'flex',
                     justifyContent: 'center',
+                    cursor: 'pointer',
                 },
             },
         },
@@ -364,8 +368,12 @@ const CustomMenuList = (componentProps) => {
     );
 };
 
-const CustomClear = () => (
-    <div className={`${BEM_BLOCK_NAME}--clear_icon_container`}>
+const CustomClear = ({ innerProps }: ClearIndicatorProps) => (
+    <div
+        className={`${BEM_BLOCK_NAME}--clear_icon_container`}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...innerProps}
+    >
         <Icon
             compact
             size={16}
@@ -469,12 +477,12 @@ const SelectNext = React.forwardRef(function SelectNext(
             ref={ref}
         >
             {label && (
-                // eslint-disable-next-line jsx-a11y/label-has-associated-control
                 <label
                     className={ClassNames(
                         'label',
                         classes.label,
                     )}
+                    htmlFor={id}
                 >
                     {label}
 

--- a/src/inputs/selectNext/selectNext.tsx
+++ b/src/inputs/selectNext/selectNext.tsx
@@ -31,6 +31,10 @@ type PropTypes = {
     */
     className?: string;
     /**
+    * A Select can clear its value using close icon
+    */
+    clearable?: boolean,
+    /**
     * A Select can be disabled
     */
     disabled?: boolean,
@@ -103,6 +107,7 @@ type PropTypes = {
 const defaultProps = {
     alwaysShowRequiredIndicator: false,
     className: null,
+    clearable: false,
     disabled: false,
     dropdownMenuMaxHeight: 180,
     dropdownMenuMinHeight: null,
@@ -355,6 +360,7 @@ const CustomOption = (componentProps) => {
     const {
         children,
         className,
+        clearable,
         disabled,
         innerRef,
         isSelected,
@@ -371,6 +377,7 @@ const CustomOption = (componentProps) => {
             {...componentProps}
             aria-selected={isSelected}
             className={optionClass}
+            isClearable={clearable}
             isDisabled={disabled}
             selectOption={selectOption}
             ref={innerRef}
@@ -397,6 +404,7 @@ const SelectNext = React.forwardRef(function SelectNext(
     const {
         alwaysShowRequiredIndicator,
         className,
+        clearable,
         disabled,
         dropdownMenuMaxHeight,
         dropdownMenuMinHeight,
@@ -465,6 +473,7 @@ const SelectNext = React.forwardRef(function SelectNext(
                 // @ts-ignore
                 dropdownMenuMaxHeight={dropdownMenuMaxHeight}
                 dropdownMenuMinHeight={dropdownMenuMinHeight}
+                isClearable={clearable}
                 isDisabled={disabled}
                 isSearchable={isSearchable}
                 menuPortalTarget={menuPortalTarget}

--- a/src/inputs/selectNext/selectNext.tsx
+++ b/src/inputs/selectNext/selectNext.tsx
@@ -19,6 +19,8 @@ import {
 } from '../../global/constants';
 import makeStyles from '../../styles/makeStyles';
 
+const BEM_BLOCK_NAME = 'react_select';
+
 type PropTypes = {
     /**
     * Forces the Select component to always show the required indicator
@@ -288,6 +290,12 @@ const useStyles = makeStyles((theme) => {
                         color: `${p.text.primary} !important`,
                     },
                 },
+                '&--clear_icon_container': {
+                    marginRight: 11,
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'center',
+                },
             },
         },
         root: {
@@ -355,6 +363,17 @@ const CustomMenuList = (componentProps) => {
         </components.MenuList>
     );
 };
+
+const CustomClear = () => (
+    <div className={`${BEM_BLOCK_NAME}--clear_icon_container`}>
+        <Icon
+            compact
+            size={16}
+            title="Clear Selection"
+            type="times"
+        />
+    </div>
+);
 
 const CustomOption = (componentProps) => {
     const {
@@ -450,6 +469,7 @@ const SelectNext = React.forwardRef(function SelectNext(
             ref={ref}
         >
             {label && (
+                // eslint-disable-next-line jsx-a11y/label-has-associated-control
                 <label
                     className={ClassNames(
                         'label',
@@ -469,6 +489,7 @@ const SelectNext = React.forwardRef(function SelectNext(
                     DropdownIndicator: CustomArrow,
                     MenuList: CustomMenuList,
                     Option: CustomOption,
+                    ClearIndicator: CustomClear,
                 }}
                 // @ts-ignore
                 dropdownMenuMaxHeight={dropdownMenuMaxHeight}


### PR DESCRIPTION
This PR introduces the `clearable` option for the `<SelectNext />` component so it can fix the following requirement:
- [BUG AB#102385](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/102385) - [Finance > Segments & Codes > Edit Code] - User should be able to nullify the "Associated HC Campus" (if they want to) of a Campus code, in the drop down menu, as it is not a required field.

<img width="241" alt="image" src="https://github.com/saddlebackdev/react-cm-ui/assets/8116485/4d684bf8-2bf5-4aeb-a494-1428760fecf2">

