### PR TITLE
[dev] Bug AB#44007 [Automated Test][Mobile][Ministry Central] Close button div overlapping on apply filter button

### DIFF
--- a/src/surfaces/drawer/drawerTitleBar.scss
+++ b/src/surfaces/drawer/drawerTitleBar.scss
@@ -31,9 +31,9 @@
         align-items: center;
         display: flex;
         height: 44px;
-        justify-content: flex-end;
+        justify-content: center;
         position: absolute;
-        right: 11px;
+        right: -6px;
         top: 50%;
         transform: translateY(-50%);
         width: 44px;


### PR DESCRIPTION
This PR addresses an old annoyance that's been around for a while regarding the 'close' button on a filter rail drawer overlapping the 'apply' button when filters are selected. Visually looks pretty much the same as before, just easier to interact with.