### PR TITLE
[dev] - Bug AB#105699 - [Connection Forms] Unable to print entries

### DIFF
--- a/src/surfaces/modal/modal.jsx
+++ b/src/surfaces/modal/modal.jsx
@@ -353,9 +353,10 @@ class Modal extends React.Component {
         const {
             onClickOutside,
             onClose,
+            isOpen,
         } = this.props;
 
-        if (this.modalContainerRef.contains(event.target) || !onClickOutside) {
+        if (!isOpen || this.modalContainerRef.contains(event.target) || !onClickOutside) {
             return;
         }
 


### PR DESCRIPTION
[dev][hotfix/1.72.0] - Bug [AB#105699](https://dev.azure.com/saddlebackchurch/b8a0d0bb-a4fe-48e3-9a60-2f1440145fc4/_workitems/edit/105699) - [Connection Forms] Unable to print entries

Description
- isOpen prop defensive check added to trigger support onClickOutside behavior