### PR TITLE
[dev] [No PBI Correct `color` type for `<Chip>` TypeScript declaration

### DIFF
--- a/src/dataDisplay/chip/chip.d.ts
+++ b/src/dataDisplay/chip/chip.d.ts
@@ -4,14 +4,17 @@ export interface ChipPropTypes {
     children?: React.ReactNode;
     className?: string;
     /* eslint-disable @typescript-eslint/indent */
-    color?: 'active' | 'action' | 'alert' |
-        'alternate' | 'bright' | 'condition' |
-        'configuration' | 'disable' | 'highlight' |
-        'inverse' | 'inverse-alternate' | 'light' |
-        'nest' | 'outline' | 'primary' |
-        'secondary' | 'static' | 'subject' |
-        'success' | 'transparent' | 'warning',
+    color?: 'cyan'
+        | 'green'
+        | 'orange'
+        | 'pink'
+        | 'purple'
+        | 'red'
+        | 'redOrange'
+        | 'sky'
+        | 'teal',
     /* eslint-enable @typescript-eslint/indent */
+    disabled?: boolean;
     fluid?: boolean;
     inverse?: boolean;
     label?: string;


### PR DESCRIPTION
* It is using actual colors from the palette, not "semantic" colors.
* Also add `disabled` prop