### PR TITLE
[dev] PBI AB#97569 Try and fix UI Docs website after #495

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -385,6 +385,11 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
     },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
     "@jimp/bmp": {
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.13.tgz",
@@ -791,6 +796,44 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "@material-ui/styles": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
+      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.3",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+    },
+    "@material-ui/utils": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
+      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
     },
     "@npmcli/move-file": {
       "version": "1.0.1",
@@ -2527,6 +2570,11 @@
         "readable-stream": "^2.3.5"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -2988,11 +3036,25 @@
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
       "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q=="
     },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
+    },
+    "csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -4484,6 +4546,15 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5215,6 +5286,11 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -5357,6 +5433,12 @@
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
       "dev": true
     },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5428,6 +5510,91 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "jss": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
+      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        }
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
+      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
+      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
+      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
+      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
+      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
+      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
+      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.10.0"
       }
     },
     "jss-rtl": {
@@ -6662,6 +6829,86 @@
       "requires": {
         "picocolors": "^0.2.1",
         "source-map": "^0.6.1"
+      }
+    },
+    "postcss-increase-specificity": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/postcss-increase-specificity/-/postcss-increase-specificity-0.6.0.tgz",
+      "integrity": "sha512-JlYoxbKBBchz69hO3s3O1CNU127bg1r72WjdePA906ovktGN/C7xdI17aai3FlBNg0i+JFJivaoh8WO1FfI1XA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^3.0.0",
+        "postcss": "^5.1.2",
+        "string.prototype.repeat": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "postcss-load-config": {
@@ -8590,6 +8837,12 @@
         "strip-ansi": "^3.0.0"
       }
     },
+    "string.prototype.repeat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+      "integrity": "sha512-1BH+X+1hSthZFW+X+JaUkjkkUPwIlLEMJBLANN3hOob3RhEk5snLWNECDnYbgn/m5c5JV7Ersu1Yubaf+05cIA==",
+      "dev": true
+    },
     "string.prototype.trimend": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
@@ -8948,6 +9201,11 @@
       "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
       "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
       "dev": true
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinycolor2": {
       "version": "1.6.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@babel/register": "^7.4.4",
+    "@material-ui/styles": "^4.11.4",
     "classnames": "^2.2.6",
     "core-js": "^3.1.3",
+    "jss": "^10.5.1",
     "jss-rtl": "^0.3.0",
     "lodash": "^4.17.21",
     "moment-timezone": "^0.5.35",
@@ -38,6 +40,7 @@
     "file-loader": "^4.0.0",
     "html-webpack-plugin": "^4.3.0",
     "mini-css-extract-plugin": "^0.9.0",
+    "postcss-increase-specificity": "0.6.0",
     "postcss-loader": "^3.0.0",
     "react-docgen": "^5.3.0",
     "resolve-url-loader": "^3.1.5",

--- a/docs/src/app/jssPreset.js
+++ b/docs/src/app/jssPreset.js
@@ -1,0 +1,43 @@
+import { jssPreset } from '@material-ui/styles';
+// eslint-disable-next-line import/no-unresolved
+import { UI_LIBRARY_ROOT_CLASS } from '@saddlebackchurch/react-cm-ui/global/constants';
+import { create } from 'jss';
+import { isFunction } from 'lodash';
+
+const UI_LIBRARY_ROOT_CLASS_WITH_SPACE = `${UI_LIBRARY_ROOT_CLASS} `;
+
+const jssClassTweaker = {
+    onCreateRule: (name, decl, options) => {
+        if (name[0] === '@' || (options.parent && options.parent.type === 'keyframes')) {
+            return null;
+        }
+
+        const plugins = options.jss.plugins.registry;
+
+        // this plugin is first, needs to start from 1 to skip it
+        for (let i = 1; i < plugins.onCreateRule.length; i += 1) {
+            const rule = plugins.onCreateRule[i](name, decl, options);
+            if (rule) {
+                if (rule.selectorText?.includes(UI_LIBRARY_ROOT_CLASS_WITH_SPACE) &&
+                    isFunction(rule.selectorText?.replaceAll)) {
+                    rule.selectorText = rule.selectorText.replaceAll(UI_LIBRARY_ROOT_CLASS_WITH_SPACE, '');
+                }
+
+                rule.selectorText = UI_LIBRARY_ROOT_CLASS_WITH_SPACE + rule.selectorText;
+
+                return rule;
+            }
+        }
+
+        return null;
+    },
+};
+
+export default function createJssPresets() {
+    return create({
+        plugins: [
+            jssClassTweaker, // must be first
+            ...jssPreset().plugins,
+        ],
+    });
+}

--- a/docs/src/index.jsx
+++ b/docs/src/index.jsx
@@ -1,15 +1,19 @@
 import '@babel/register';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+// eslint-disable-next-line import/no-unresolved
 import 'css-cm-ui';
 
 import { browserHistory, Router } from 'react-router';
+import { StylesProvider } from '@material-ui/styles';
+// eslint-disable-next-line import/no-unresolved
 import { theme, ThemeProvider } from '@saddlebackchurch/react-cm-ui/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { appReduxStore } from './global/configureReduxStore';
 import routes from './routes';
+import jssPreset from './app/jssPreset';
 
 /**
  * `theme` is being pushed into the global window object for documentation purposes. This gives
@@ -35,17 +39,21 @@ const onUpdate = () => {
     }
 };
 
+const jss = jssPreset();
+
 const render = () => {
     ReactDOM.render(
-        <ThemeProvider theme={theme}>
-            <Provider store={appReduxStore}>
-                <Router
-                    history={browserHistory}
-                    onUpdate={onUpdate}
-                    routes={routes}
-                />
-            </Provider>
-        </ThemeProvider>,
+        <StylesProvider jss={jss}>
+            <ThemeProvider theme={theme}>
+                <Provider store={appReduxStore}>
+                    <Router
+                        history={browserHistory}
+                        onUpdate={onUpdate}
+                        routes={routes}
+                    />
+                </Provider>
+            </ThemeProvider>
+        </StylesProvider>,
         document.getElementById('coreApp'),
     );
 };

--- a/docs/template.ejs
+++ b/docs/template.ejs
@@ -1,11 +1,19 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="hc-ui">
 <head>
     <meta charset="utf-8">
     <title><%= htmlWebpackPlugin.options.title %></title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <style type="text/css">
+        html {
+            font-family: sans-serif;
+            -ms-text-size-adjust: 100%;
+            -webkit-text-size-adjust: 100%;
+        }
+    </style>
 </head>
 <body>
     <div id="coreApp"></div>

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const increaseSpecificity = require('postcss-increase-specificity');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
@@ -61,7 +62,16 @@ module.exports = (env, options) => {
                             loader: 'postcss-loader',
                             options: {
                                 plugins: [
-                                    autoprefixer(),
+                                    // TODO/FIXME: Ilya do we need to use increaseSpecificity plugin?  If so, in what order?
+                                    // increaseSpecificity({
+                                    //     stackableRoot: '.hc-ui',
+                                    //     repeat: 1,
+                                    // }),
+                                    autoprefixer(), // do we still need this here?
+                                    // increaseSpecificity({
+                                    //     stackableRoot: '.hc-ui',
+                                    //     repeat: 1,
+                                    // }),
                                 ],
                                 sourceMap: true,
                             },
@@ -134,6 +144,13 @@ module.exports = (env, options) => {
         },
         plugins: [
             new webpack.LoaderOptionsPlugin({
+                // TODO/FIXME: Ilya do we need this?
+                // options: {
+                //     postcss() {
+                //         // eslint-disable-next-line global-require
+                //         return [require('autoprefixer')];
+                //     },
+                // },
                 proxy: {
                     '*': 'http://0.0.0.0:5000',
                 },


### PR DESCRIPTION
Trying to fix regression in the [CM UI Docs Website](https://cm-ui-docs.saddleback.com/) after #495.

This is a screenshot of UI Docs w/ React CM UI 10.11.0 ([Build 20240523.1](https://dev.azure.com/saddlebackchurch/Church%20Management/_build/results?buildId=103213&view=results) / [Release 369](https://dev.azure.com/saddlebackchurch/Church%20Management/_releaseProgress?_a=release-pipeline-progress&releaseId=29143)):

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/afb274b2-0714-4274-9f44-adfe82baf168)

This is the prior release - React CM UI 10.10.1 ([Build 20240501.2](https://dev.azure.com/saddlebackchurch/Church%20Management/_build/results?buildId=101916&view=results) / [Release 368](https://dev.azure.com/saddlebackchurch/Church%20Management/_releaseProgress?_a=release-pipeline-progress&releaseId=28788)) _(presently redeployed to prod)_

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/3402460e-3d19-483d-9667-3c7681da435a)

With the change set in this PR, it's close but not quite there yet.  I think it's something to do with Autoprefixer and Increase Specificity Post CSS plugins in Webpack, but I'm not 100% sure and I need help from the UI brains! =)

Here's my local w/ these changes.  Some things are close; some things are off (e.g. navigation links on the right)

![image](https://github.com/saddlebackdev/react-cm-ui/assets/4349658/ff7ce9aa-1e8e-43aa-ac98-2deef169f97e)
